### PR TITLE
feat: post를 멤버id와 status로 찾는 기능 추가

### DIFF
--- a/src/main/java/com/zerobase/oriticket/domain/post/controller/PostController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/controller/PostController.java
@@ -10,8 +10,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")

--- a/src/main/java/com/zerobase/oriticket/domain/post/controller/PostController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/controller/PostController.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
@@ -38,14 +40,14 @@ public class PostController {
     }
 
     @DeleteMapping
-    private Long delete(
+    public Long delete(
             @RequestParam("id") Long salePostId
     ) {
         return postService.delete(salePostId);
     }
 
     @PatchMapping("/report")
-    private ResponseEntity<PostResponse> updateToReported(
+    public ResponseEntity<PostResponse> updateToReported(
             @RequestBody UpdateStatusToReportedPostRequest request
     ){
         Post salePost = postService.updateToReported(request);

--- a/src/main/java/com/zerobase/oriticket/domain/post/controller/PostFetchController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/controller/PostFetchController.java
@@ -1,0 +1,43 @@
+package com.zerobase.oriticket.domain.post.controller;
+
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.dto.PostResponse;
+import com.zerobase.oriticket.domain.post.entity.Post;
+import com.zerobase.oriticket.domain.post.service.PostFetchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class PostFetchController {
+    private final PostFetchService postFetchService;
+
+    @GetMapping("/members/{memberId}/posts")
+    public ResponseEntity<List<PostResponse>> get(
+            @PathVariable("memberId") Long memberId,
+            @RequestParam("status") List<String> statusList
+    ){
+
+        List<SaleStatus> saleStatusList = statusList.stream()
+                .map(String::toUpperCase)
+                .map(SaleStatus::valueOf)
+                .toList();
+
+        System.out.println(saleStatusList);
+
+        List<Post> postList = postFetchService.get(memberId, saleStatusList);
+
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(postList.stream()
+                        .map(PostResponse::fromEntity)
+                        .toList());
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/repository/PostRepository.java
@@ -1,9 +1,13 @@
 package com.zerobase.oriticket.domain.post.repository;
 
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
 import com.zerobase.oriticket.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByMemberIdAndSaleStatusIn(Long memberId, List<SaleStatus> saleStatusList);
 }

--- a/src/main/java/com/zerobase/oriticket/domain/post/service/PostFetchService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/service/PostFetchService.java
@@ -1,0 +1,22 @@
+package com.zerobase.oriticket.domain.post.service;
+
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.entity.Post;
+import com.zerobase.oriticket.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostFetchService {
+
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public List<Post> get(Long memberId, List<SaleStatus> saleStatusList) {
+        return postRepository.findAllByMemberIdAndSaleStatusIn(memberId, saleStatusList);
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/post/service/PostService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/service/PostService.java
@@ -74,8 +74,10 @@ public class PostService {
         validateCanUpdateToReportedStatus(salePost.getSaleStatus());
 
         salePost.setSaleStatus(SaleStatus.REPORTED);
+        Post updatedPost = postRepository.save(salePost);
+        postSearchRepository.save(PostSearchDocument.fromEntity(updatedPost));
 
-        return postRepository.save(salePost);
+        return updatedPost;
     }
 
     private Ticket registerTicket(RegisterPostRequest request) {

--- a/src/main/java/com/zerobase/oriticket/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/transaction/service/TransactionService.java
@@ -1,5 +1,7 @@
 package com.zerobase.oriticket.domain.transaction.service;
 
+import com.zerobase.oriticket.domain.elasticsearch.post.entity.PostSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.post.repository.PostSearchRepository;
 import com.zerobase.oriticket.domain.elasticsearch.transaction.entity.TransactionSearchDocument;
 import com.zerobase.oriticket.domain.elasticsearch.transaction.repository.TransactionSearchRepository;
 import com.zerobase.oriticket.domain.post.constants.SaleStatus;
@@ -27,6 +29,7 @@ public class TransactionService {
     private final TransactionRepository transactionRepository;
     private final TransactionSearchRepository transactionSearchRepository;
     private final PostRepository postRepository;
+    private final PostSearchRepository postSearchRepository;
 
     private static final String STARTED_AT = "startedAt";
 
@@ -46,6 +49,7 @@ public class TransactionService {
         transactionSearchRepository.save(TransactionSearchDocument.fromEntity(transaction));
         salePost.setSaleStatus(SaleStatus.TRADING);
         postRepository.save(salePost);
+        postSearchRepository.save(PostSearchDocument.fromEntity(salePost));
 
         return transaction;
     }

--- a/src/main/java/com/zerobase/oriticket/domain/transaction/service/TransactionUpdateService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/transaction/service/TransactionUpdateService.java
@@ -2,6 +2,8 @@ package com.zerobase.oriticket.domain.transaction.service;
 
 import com.zerobase.oriticket.domain.chat.entity.ChatRoom;
 import com.zerobase.oriticket.domain.chat.repository.ChatRoomRepository;
+import com.zerobase.oriticket.domain.elasticsearch.post.entity.PostSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.post.repository.PostSearchRepository;
 import com.zerobase.oriticket.domain.elasticsearch.transaction.entity.TransactionSearchDocument;
 import com.zerobase.oriticket.domain.elasticsearch.transaction.repository.TransactionSearchRepository;
 import com.zerobase.oriticket.domain.post.constants.SaleStatus;
@@ -28,6 +30,7 @@ public class TransactionUpdateService {
 
     private final TransactionRepository transactionRepository;
     private final PostRepository postRepository;
+    private final PostSearchRepository postSearchRepository;
     private final TransactionSearchRepository transactionSearchRepository;
     private final ChatRoomRepository chatRoomRepository;
 
@@ -62,6 +65,7 @@ public class TransactionUpdateService {
         Post salePost = transaction.getSalePost();
         salePost.setSaleStatus(SaleStatus.SOLD);
         postRepository.save(salePost);
+        postSearchRepository.save(PostSearchDocument.fromEntity(salePost));
 
         endChatRoom(transaction.getTransactionId());
 
@@ -82,6 +86,7 @@ public class TransactionUpdateService {
         Post salePost = transaction.getSalePost();
         salePost.setSaleStatus(SaleStatus.FOR_SALE);
         postRepository.save(salePost);
+        postSearchRepository.save(PostSearchDocument.fromEntity(salePost));
 
         endChatRoom(transaction.getTransactionId());
 
@@ -102,6 +107,7 @@ public class TransactionUpdateService {
         Post salePost = transaction.getSalePost();
         salePost.setSaleStatus(SaleStatus.REPORTED);
         postRepository.save(salePost);
+        postSearchRepository.save(PostSearchDocument.fromEntity(salePost));
 
         endChatRoom(transaction.getTransactionId());
 

--- a/src/main/java/com/zerobase/oriticket/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/zerobase/oriticket/global/exception/CustomExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.zerobase.oriticket.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -7,22 +8,29 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
+@Slf4j
 public class CustomExceptionHandler {
 
     @ExceptionHandler(AbstractException.class)
     protected ResponseEntity<Void> handleCustomException(AbstractException e) {
+        log.error("CustomException..........");
+        log.error(e.getMessage());
 
         return ResponseEntity.status(e.getErrorCode()).build();
     }
 
     @ExceptionHandler(TypeMismatchException.class)
     protected ResponseEntity<Void> handleRuntimeException(TypeMismatchException e) {
+        log.error("TypeMismatchException..........");
+        log.error(e.getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     }
 
     @ExceptionHandler(RuntimeException.class)
     protected ResponseEntity<Void> handleRuntimeException(RuntimeException e) {
+        log.error("RuntimeException..........");
+        log.error(e.getMessage());
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }

--- a/src/test/java/com/zerobase/oriticket/post/controller/PostFetchControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/PostFetchControllerTest.java
@@ -1,0 +1,204 @@
+package com.zerobase.oriticket.post.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.controller.PostFetchController;
+import com.zerobase.oriticket.domain.post.entity.*;
+import com.zerobase.oriticket.domain.post.service.PostFetchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PostFetchController.class)
+public class PostFetchControllerTest {
+
+    @MockBean
+    private PostFetchService postFetchService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 15000;
+    private final static Boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "A열 4석";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Long memberId, SaleStatus saleStatus, Ticket ticket){
+        return Post.builder()
+                .salePostId(salePostId)
+                .memberId(memberId)
+                .ticket(ticket)
+                .saleStatus(saleStatus)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 판매중인 SalePost 조회 성공")
+    void successGetByMemberIdAndSaleStatus() throws Exception {
+        //given
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket1 = createTicket(1L, sports, stadium, awayTeam);
+        Ticket ticket2 = createTicket(2L, sports, stadium, awayTeam);
+        Post post1 = createPost(1L, 1L, SaleStatus.FOR_SALE, ticket1);
+        Post post2 = createPost(2L, 1L, SaleStatus.TRADING, ticket2);
+        List<Post> postList = Arrays.asList(post1, post2);
+
+        given(postFetchService.get(anyLong(), any(List.class)))
+                .willReturn(postList);
+
+        //when
+        //then
+        mockMvc.perform(get("/members/1/posts?status=for_sale, trading"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.[0].salePostId").value(1L))
+                .andExpect(jsonPath("$.[0].memberId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.sportsId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.stadiumId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.quantity").value(1))
+                .andExpect(jsonPath("$.[0].ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.[0].ticket.originalPrice").value(15000))
+                .andExpect(jsonPath("$.[0].ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.[0].ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.[0].ticket.seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.[0].ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.[0].ticket.note").value("note"))
+                .andExpect(jsonPath("$.[0].saleStatus").value("FOR_SALE"))
+                .andExpect(jsonPath("$.[0].createdAt").exists())
+                .andExpect(jsonPath("$.[1].salePostId").value(2L))
+                .andExpect(jsonPath("$.[1].memberId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.sportsId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.stadiumId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.quantity").value(1))
+                .andExpect(jsonPath("$.[1].ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.[1].ticket.originalPrice").value(15000))
+                .andExpect(jsonPath("$.[1].ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.[1].ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.[1].ticket.seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.[1].ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.[1].ticket.note").value("note"))
+                .andExpect(jsonPath("$.[1].saleStatus").value("TRADING"))
+                .andExpect(jsonPath("$.[1].createdAt").exists());
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 판매종료인 SalePost 조회 성공")
+    void successGetByMemberIdAndEndStatus() throws Exception {
+        //given
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket1 = createTicket(1L, sports, stadium, awayTeam);
+        Ticket ticket2 = createTicket(2L, sports, stadium, awayTeam);
+        Post post1 = createPost(1L, 1L, SaleStatus.SOLD, ticket1);
+        Post post2 = createPost(2L, 1L, SaleStatus.REPORTED, ticket2);
+        List<Post> postList = Arrays.asList(post1, post2);
+
+        given(postFetchService.get(anyLong(), any(List.class)))
+                .willReturn(postList);
+
+        //when
+        //then
+        mockMvc.perform(get("/members/1/posts?status=sold, reported"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.[0].salePostId").value(1L))
+                .andExpect(jsonPath("$.[0].memberId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.sportsId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.stadiumId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.quantity").value(1))
+                .andExpect(jsonPath("$.[0].ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.[0].ticket.originalPrice").value(15000))
+                .andExpect(jsonPath("$.[0].ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.[0].ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.[0].ticket.seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.[0].ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.[0].ticket.note").value("note"))
+                .andExpect(jsonPath("$.[0].saleStatus").value("SOLD"))
+                .andExpect(jsonPath("$.[0].createdAt").exists())
+                .andExpect(jsonPath("$.[1].salePostId").value(2L))
+                .andExpect(jsonPath("$.[1].memberId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.sportsId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.stadiumId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.quantity").value(1))
+                .andExpect(jsonPath("$.[1].ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.[1].ticket.originalPrice").value(15000))
+                .andExpect(jsonPath("$.[1].ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.[1].ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.[1].ticket.seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.[1].ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.[1].ticket.note").value("note"))
+                .andExpect(jsonPath("$.[1].saleStatus").value("REPORTED"))
+                .andExpect(jsonPath("$.[1].createdAt").exists());
+    }
+
+}

--- a/src/test/java/com/zerobase/oriticket/post/service/PostFetchServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/service/PostFetchServiceTest.java
@@ -1,0 +1,201 @@
+package com.zerobase.oriticket.post.service;
+
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.entity.*;
+import com.zerobase.oriticket.domain.post.repository.PostRepository;
+import com.zerobase.oriticket.domain.post.service.PostFetchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class PostFetchServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostFetchService postFetchService;
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 15000;
+    private final static Boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "A열 4석";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Long memberId, SaleStatus saleStatus, Ticket ticket){
+        return Post.builder()
+                .salePostId(salePostId)
+                .memberId(memberId)
+                .ticket(ticket)
+                .saleStatus(saleStatus)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 판매중인 SalePost 조회 성공")
+    void successGetSale(){
+        //given
+        List<SaleStatus> saleStatusList = Arrays.asList(SaleStatus.FOR_SALE, SaleStatus.TRADING);
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket1 = createTicket(1L, sports, stadium, awayTeam);
+        Ticket ticket2 = createTicket(2L, sports, stadium, awayTeam);
+        Post post1 = createPost(1L, 1L, SaleStatus.FOR_SALE, ticket1);
+        Post post2 = createPost(2L, 1L, SaleStatus.TRADING, ticket2);
+        List<Post> postList = Arrays.asList(post1, post2);
+
+        given(postRepository.findAllByMemberIdAndSaleStatusIn(anyLong(), any(List.class)))
+                .willReturn(postList);
+
+        //when
+        List<Post> fetchedPost = postFetchService.get(1L, saleStatusList);
+
+        //then
+        assertThat(fetchedPost.get(0).getSalePostId()).isEqualTo(1L);
+        assertThat(fetchedPost.get(0).getMemberId()).isEqualTo(1L);
+        assertThat(fetchedPost.get(0).getTicket().getTicketId()).isEqualTo(1L);
+        assertThat(fetchedPost.get(0).getTicket().getSports()).isEqualTo(sports);
+        assertThat(fetchedPost.get(0).getTicket().getStadium()).isEqualTo(stadium);
+        assertThat(fetchedPost.get(0).getTicket().getAwayTeam()).isEqualTo(awayTeam);
+        assertThat(fetchedPost.get(0).getTicket().getQuantity()).isEqualTo(1);
+        assertThat(fetchedPost.get(0).getTicket().getSalePrice()).isEqualTo(10000);
+        assertThat(fetchedPost.get(0).getTicket().getOriginalPrice()).isEqualTo(15000);
+        assertNotNull(fetchedPost.get(0).getTicket().getExpirationAt());
+        assertThat(fetchedPost.get(0).getTicket().getIsSuccessive()).isEqualTo(false);
+        assertThat(fetchedPost.get(0).getTicket().getSeatInfo()).isEqualTo("A열 4석");
+        assertThat(fetchedPost.get(0).getTicket().getImgUrl()).isEqualTo("image url");
+        assertThat(fetchedPost.get(0).getTicket().getNote()).isEqualTo("note");
+        assertThat(fetchedPost.get(0).getSaleStatus()).isEqualTo(SaleStatus.FOR_SALE);
+        assertNotNull(fetchedPost.get(0).getCreatedAt());
+        assertThat(fetchedPost.get(1).getSalePostId()).isEqualTo(2L);
+        assertThat(fetchedPost.get(1).getMemberId()).isEqualTo(1L);
+        assertThat(fetchedPost.get(1).getTicket().getTicketId()).isEqualTo(2L);
+        assertThat(fetchedPost.get(1).getTicket().getSports()).isEqualTo(sports);
+        assertThat(fetchedPost.get(1).getTicket().getStadium()).isEqualTo(stadium);
+        assertThat(fetchedPost.get(1).getTicket().getAwayTeam()).isEqualTo(awayTeam);
+        assertThat(fetchedPost.get(1).getTicket().getQuantity()).isEqualTo(1);
+        assertThat(fetchedPost.get(1).getTicket().getSalePrice()).isEqualTo(10000);
+        assertThat(fetchedPost.get(1).getTicket().getOriginalPrice()).isEqualTo(15000);
+        assertNotNull(fetchedPost.get(1).getTicket().getExpirationAt());
+        assertThat(fetchedPost.get(1).getTicket().getIsSuccessive()).isEqualTo(false);
+        assertThat(fetchedPost.get(1).getTicket().getSeatInfo()).isEqualTo("A열 4석");
+        assertThat(fetchedPost.get(1).getTicket().getImgUrl()).isEqualTo("image url");
+        assertThat(fetchedPost.get(1).getTicket().getNote()).isEqualTo("note");
+        assertThat(fetchedPost.get(1).getSaleStatus()).isEqualTo(SaleStatus.TRADING);
+        assertNotNull(fetchedPost.get(1).getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 판매종료된 SalePost 조회 성공")
+    void successGetEnd(){
+        //given
+        List<SaleStatus> saleStatusList = Arrays.asList(SaleStatus.SOLD, SaleStatus.REPORTED);
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket1 = createTicket(1L, sports, stadium, awayTeam);
+        Ticket ticket2 = createTicket(2L, sports, stadium, awayTeam);
+        Post post1 = createPost(1L, 1L, SaleStatus.SOLD, ticket1);
+        Post post2 = createPost(2L, 1L, SaleStatus.REPORTED, ticket2);
+        List<Post> postList = Arrays.asList(post1, post2);
+
+        given(postRepository.findAllByMemberIdAndSaleStatusIn(anyLong(), any(List.class)))
+                .willReturn(postList);
+
+        //when
+        List<Post> fetchedPost = postFetchService.get(1L, saleStatusList);
+
+        //then
+        assertThat(fetchedPost.get(0).getSalePostId()).isEqualTo(1L);
+        assertThat(fetchedPost.get(0).getMemberId()).isEqualTo(1L);
+        assertThat(fetchedPost.get(0).getTicket().getTicketId()).isEqualTo(1L);
+        assertThat(fetchedPost.get(0).getTicket().getSports()).isEqualTo(sports);
+        assertThat(fetchedPost.get(0).getTicket().getStadium()).isEqualTo(stadium);
+        assertThat(fetchedPost.get(0).getTicket().getAwayTeam()).isEqualTo(awayTeam);
+        assertThat(fetchedPost.get(0).getTicket().getQuantity()).isEqualTo(1);
+        assertThat(fetchedPost.get(0).getTicket().getSalePrice()).isEqualTo(10000);
+        assertThat(fetchedPost.get(0).getTicket().getOriginalPrice()).isEqualTo(15000);
+        assertNotNull(fetchedPost.get(0).getTicket().getExpirationAt());
+        assertThat(fetchedPost.get(0).getTicket().getIsSuccessive()).isEqualTo(false);
+        assertThat(fetchedPost.get(0).getTicket().getSeatInfo()).isEqualTo("A열 4석");
+        assertThat(fetchedPost.get(0).getTicket().getImgUrl()).isEqualTo("image url");
+        assertThat(fetchedPost.get(0).getTicket().getNote()).isEqualTo("note");
+        assertThat(fetchedPost.get(0).getSaleStatus()).isEqualTo(SaleStatus.SOLD);
+        assertNotNull(fetchedPost.get(0).getCreatedAt());
+        assertThat(fetchedPost.get(1).getSalePostId()).isEqualTo(2L);
+        assertThat(fetchedPost.get(1).getMemberId()).isEqualTo(1L);
+        assertThat(fetchedPost.get(1).getTicket().getTicketId()).isEqualTo(2L);
+        assertThat(fetchedPost.get(1).getTicket().getSports()).isEqualTo(sports);
+        assertThat(fetchedPost.get(1).getTicket().getStadium()).isEqualTo(stadium);
+        assertThat(fetchedPost.get(1).getTicket().getAwayTeam()).isEqualTo(awayTeam);
+        assertThat(fetchedPost.get(1).getTicket().getQuantity()).isEqualTo(1);
+        assertThat(fetchedPost.get(1).getTicket().getSalePrice()).isEqualTo(10000);
+        assertThat(fetchedPost.get(1).getTicket().getOriginalPrice()).isEqualTo(15000);
+        assertNotNull(fetchedPost.get(1).getTicket().getExpirationAt());
+        assertThat(fetchedPost.get(1).getTicket().getIsSuccessive()).isEqualTo(false);
+        assertThat(fetchedPost.get(1).getTicket().getSeatInfo()).isEqualTo("A열 4석");
+        assertThat(fetchedPost.get(1).getTicket().getImgUrl()).isEqualTo("image url");
+        assertThat(fetchedPost.get(1).getTicket().getNote()).isEqualTo("note");
+        assertThat(fetchedPost.get(1).getSaleStatus()).isEqualTo(SaleStatus.REPORTED);
+        assertNotNull(fetchedPost.get(1).getCreatedAt());
+    }
+}

--- a/src/test/java/com/zerobase/oriticket/post/service/PostServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/service/PostServiceTest.java
@@ -305,14 +305,36 @@ public class PostServiceTest {
         given(postRepository.save(any(Post.class)))
                 .willReturn(reportedPost);
 
+        ArgumentCaptor<PostSearchDocument> captor =
+                ArgumentCaptor.forClass(PostSearchDocument.class);
+
         //when
         Post fetchedPost = postService.updateToReported(updateRequest);
 
         //then
+        then(postSearchRepository).should(times(1)).save(captor.capture());
+        PostSearchDocument fetchedPostDocumentCaptor = captor.getValue();
+
         assertThat(fetchedPost.getSalePostId()).isEqualTo(3L);
         assertThat(fetchedPost.getMemberId()).isEqualTo(2L);
         assertThat(fetchedPost.getTicket()).isEqualTo(ticket);
         assertThat(fetchedPost.getSaleStatus()).isEqualTo(SaleStatus.REPORTED);
+
+        assertThat(fetchedPostDocumentCaptor.getSalePostId()).isEqualTo(3L);
+        assertThat(fetchedPostDocumentCaptor.getMemberName()).isEqualTo("seller name");
+        assertThat(fetchedPostDocumentCaptor.getSportsName()).isEqualTo("농구");
+        assertThat(fetchedPostDocumentCaptor.getStadiumName()).isEqualTo("고척돔");
+        assertThat(fetchedPostDocumentCaptor.getHomeTeamName()).isEqualTo("키움");
+        assertThat(fetchedPostDocumentCaptor.getAwayTeamName()).isEqualTo("기아");
+        assertThat(fetchedPostDocumentCaptor.getQuantity()).isEqualTo(1);
+        assertThat(fetchedPostDocumentCaptor.getSalePrice()).isEqualTo(10000);
+        assertThat(fetchedPostDocumentCaptor.getOriginalPrice()).isEqualTo(15000);
+        assertNotNull(fetchedPostDocumentCaptor.getExpirationAt());
+        assertThat(fetchedPostDocumentCaptor.getIsSuccessive()).isEqualTo(false);
+        assertThat(fetchedPostDocumentCaptor.getSeatInfo()).isEqualTo("A열 4석");
+        assertThat(fetchedPostDocumentCaptor.getImgUrl()).isEqualTo("image url");
+        assertThat(fetchedPostDocumentCaptor.getNote()).isEqualTo("note");
+        assertThat(fetchedPostDocumentCaptor.getSaleStatus()).isEqualTo(SaleStatus.REPORTED);
         assertNotNull(fetchedPost.getCreatedAt());
     }
 }

--- a/src/test/java/com/zerobase/oriticket/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/transaction/service/TransactionServiceTest.java
@@ -1,9 +1,10 @@
 package com.zerobase.oriticket.transaction.service;
 
+import com.zerobase.oriticket.domain.elasticsearch.post.repository.PostSearchRepository;
 import com.zerobase.oriticket.domain.elasticsearch.transaction.entity.TransactionSearchDocument;
 import com.zerobase.oriticket.domain.elasticsearch.transaction.repository.TransactionSearchRepository;
 import com.zerobase.oriticket.domain.post.constants.SaleStatus;
-import com.zerobase.oriticket.domain.post.entity.Post;
+import com.zerobase.oriticket.domain.post.entity.*;
 import com.zerobase.oriticket.domain.post.repository.PostRepository;
 import com.zerobase.oriticket.domain.transaction.constants.TransactionStatus;
 import com.zerobase.oriticket.domain.transaction.dto.RegisterTransactionRequest;
@@ -47,8 +48,68 @@ public class TransactionServiceTest {
     @Mock
     private PostRepository postRepository;
 
+    @Mock
+    private PostSearchRepository postSearchRepository;
+
     @InjectMocks
     private TransactionService transactionService;
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 15000;
+    private final static Boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "A열 4석";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Ticket ticket){
+        return Post.builder()
+                .salePostId(salePostId)
+                .ticket(ticket)
+                .saleStatus(SaleStatus.FOR_SALE)
+                .build();
+    }
 
     private Post createPost(Long salePostId){
         return Post.builder()
@@ -81,7 +142,11 @@ public class TransactionServiceTest {
                         .salePostId(1L)
                         .memberId(2L)
                         .build();
-        Post salePost = createPost(1L);
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket = createTicket(1L, sports, stadium, awayTeam);
+        Post salePost = createPost(1L, ticket);
         Transaction transaction = createTransaction(10L, salePost, 2L);
 
         given(postRepository.findById(anyLong()))

--- a/src/test/java/com/zerobase/oriticket/transaction/service/TransactionUpdateServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/transaction/service/TransactionUpdateServiceTest.java
@@ -2,10 +2,11 @@ package com.zerobase.oriticket.transaction.service;
 
 import com.zerobase.oriticket.domain.chat.entity.ChatRoom;
 import com.zerobase.oriticket.domain.chat.repository.ChatRoomRepository;
+import com.zerobase.oriticket.domain.elasticsearch.post.repository.PostSearchRepository;
 import com.zerobase.oriticket.domain.elasticsearch.transaction.entity.TransactionSearchDocument;
 import com.zerobase.oriticket.domain.elasticsearch.transaction.repository.TransactionSearchRepository;
 import com.zerobase.oriticket.domain.post.constants.SaleStatus;
-import com.zerobase.oriticket.domain.post.entity.Post;
+import com.zerobase.oriticket.domain.post.entity.*;
 import com.zerobase.oriticket.domain.post.repository.PostRepository;
 import com.zerobase.oriticket.domain.transaction.constants.TransactionStatus;
 import com.zerobase.oriticket.domain.transaction.dto.UpdateStatusToReceivedTransactionRequest;
@@ -43,6 +44,9 @@ public class TransactionUpdateServiceTest {
     private PostRepository postRepository;
 
     @Mock
+    private PostSearchRepository postSearchRepository;
+
+    @Mock
     private TransactionSearchRepository transactionSearchRepository;
 
     @Mock
@@ -50,6 +54,63 @@ public class TransactionUpdateServiceTest {
 
     @InjectMocks
     private TransactionUpdateService transactionUpdateService;
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 15000;
+    private final static Boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "A열 4석";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, SaleStatus status, Ticket ticket){
+        return Post.builder()
+                .salePostId(salePostId)
+                .ticket(ticket)
+                .saleStatus(status)
+                .build();
+    }
 
     private Post createPost(Long salePostId, SaleStatus status){
         return Post.builder()
@@ -135,7 +196,11 @@ public class TransactionUpdateServiceTest {
                 UpdateStatusTransactionRequest.builder()
                         .transactionId(12L)
                         .build();
-        Post salePost = createPost(2L, SaleStatus.TRADING);
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket = createTicket(1L, sports, stadium, awayTeam);
+        Post salePost = createPost(2L, SaleStatus.TRADING, ticket);
         Transaction transaction = createTransaction(12L, salePost, 3L,
                 10000, TransactionStatus.RECEIVED, LocalDateTime.now(), null);
 
@@ -191,7 +256,11 @@ public class TransactionUpdateServiceTest {
                 UpdateStatusTransactionRequest.builder()
                         .transactionId(12L)
                         .build();
-        Post salePost = createPost(2L, SaleStatus.TRADING);
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket = createTicket(1L, sports, stadium, awayTeam);
+        Post salePost = createPost(2L, SaleStatus.TRADING, ticket);
         Transaction transaction = createTransaction(12L, salePost, 3L,
                 10000, TransactionStatus.RECEIVED, LocalDateTime.now(), null);
 
@@ -247,7 +316,11 @@ public class TransactionUpdateServiceTest {
                 UpdateStatusTransactionRequest.builder()
                         .transactionId(12L)
                         .build();
-        Post salePost = createPost(2L, SaleStatus.TRADING);
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket = createTicket(1L, sports, stadium, awayTeam);
+        Post salePost = createPost(2L, SaleStatus.TRADING, ticket);
         Transaction transaction = createTransaction(12L, salePost, 3L,
                 10000, TransactionStatus.RECEIVED, LocalDateTime.now(), null);
 


### PR DESCRIPTION
## 변경사항

### Post
- 컨트롤러의 메서드의 private 을 public으로 수정
- MemberId와 status를 받아서 특정 멤버의 특정 status를 가진 post를 가져올 수 있는 PostFetch 추가
- Post 상태 업데이트시 PostSearchDocument의 상태가 변경되지 않았던점 수정
- Transaction 상태 업데이트시 Post의 상태가 업데이트 될 때 PostSearchDocument의 상태가 변경되지 않았던점 수정

## 변경 예정
- Member 기능 개발 완료시 Post, Transaction에 Member 연동 예정

## 테스트
- [x] 테스트 코드
- [x] API 테스트