### PR TITLE
Feature/likes

### DIFF
--- a/src/main/java/com/zerobase/oriticket/domain/post/controller/LikesController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/controller/LikesController.java
@@ -1,0 +1,54 @@
+package com.zerobase.oriticket.domain.post.controller;
+
+import com.zerobase.oriticket.domain.post.dto.LikesResponse;
+import com.zerobase.oriticket.domain.post.dto.RegisterLikesRequest;
+import com.zerobase.oriticket.domain.post.entity.Likes;
+import com.zerobase.oriticket.domain.post.service.LikesService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class LikesController {
+
+    private final LikesService likesService;
+
+    @PostMapping("/posts/{salePostId}/likes")
+    public ResponseEntity<LikesResponse> register(
+            @PathVariable("salePostId") Long salePostId,
+            @RequestBody RegisterLikesRequest request
+    ){
+        Likes likes = likesService.register(salePostId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(LikesResponse.fromEntity(likes));
+    }
+
+    @DeleteMapping("/posts/{salePostId}/likes")
+    public ResponseEntity<Long> delete(
+            @PathVariable("salePostId") Long salePostId,
+            @RequestParam("memberId") Long memberId
+    ){
+        Long likesId = likesService.delete(salePostId, memberId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(likesId);
+    }
+
+    @GetMapping("/members/{memberId}/likes")
+    public ResponseEntity<List<LikesResponse>> get(
+            @PathVariable("memberId") Long memberId
+    ){
+        List<Likes> likesList = likesService.get(memberId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(likesList.stream()
+                        .map(LikesResponse::fromEntity)
+                        .toList());
+
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/post/dto/LikesResponse.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/dto/LikesResponse.java
@@ -1,0 +1,22 @@
+package com.zerobase.oriticket.domain.post.dto;
+
+import com.zerobase.oriticket.domain.post.entity.Likes;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LikesResponse {
+    private Long likesId;
+    private Long memberId;
+    private PostResponse salePost;
+
+    public static LikesResponse fromEntity(Likes likes){
+
+        return LikesResponse.builder()
+                .likesId(likes.getLikesId())
+                .memberId(likes.getMemberId())
+                .salePost(PostResponse.fromEntity(likes.getSalePost()))
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/post/dto/RegisterAwayTeamRequest.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/dto/RegisterAwayTeamRequest.java
@@ -19,7 +19,7 @@ public class RegisterAwayTeamRequest {
     public AwayTeam toEntity(Sports sports){
         return AwayTeam.builder()
                 .sports(sports)
-                .awayTeamName(awayTeamName)
+                .awayTeamName(this.awayTeamName)
                 .build();
     }
 }

--- a/src/main/java/com/zerobase/oriticket/domain/post/dto/RegisterLikesRequest.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/dto/RegisterLikesRequest.java
@@ -1,0 +1,25 @@
+package com.zerobase.oriticket.domain.post.dto;
+
+import com.zerobase.oriticket.domain.post.entity.Likes;
+import com.zerobase.oriticket.domain.post.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterLikesRequest {
+
+    private Long memberId;
+
+    public Likes toEntity(Post salePost){
+        return Likes.builder()
+                .memberId(this.memberId)
+                .salePost(salePost)
+                .build();
+    }
+
+}

--- a/src/main/java/com/zerobase/oriticket/domain/post/dto/TicketResponse.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/dto/TicketResponse.java
@@ -1,18 +1,19 @@
 package com.zerobase.oriticket.domain.post.dto;
 
 import com.zerobase.oriticket.domain.post.entity.Ticket;
-
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
 public class TicketResponse {
 
-    private Long sportsId;
-    private Long stadiumId;
-    private Long awayTeamId;
+    private String sportsName;
+    private String stadiumName;
+    private String homeTeamName;
+    private String awayTeamName;
 
     private int quantity;
     private int salePrice;
@@ -27,9 +28,10 @@ public class TicketResponse {
 
     public static TicketResponse fromEntity(Ticket ticket) {
         return TicketResponse.builder()
-                .sportsId(ticket.getSports().getSportsId())
-                .stadiumId(ticket.getStadium().getStadiumId())
-                .awayTeamId(ticket.getAwayTeam().getAwayTeamId())
+                .sportsName(ticket.getSports().getSportsName())
+                .stadiumName(ticket.getStadium().getStadiumName())
+                .homeTeamName(ticket.getStadium().getHomeTeamName())
+                .awayTeamName(ticket.getAwayTeam().getAwayTeamName())
                 .quantity(ticket.getQuantity())
                 .salePrice(ticket.getSalePrice())
                 .originalPrice(ticket.getOriginalPrice())

--- a/src/main/java/com/zerobase/oriticket/domain/post/entity/Likes.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/entity/Likes.java
@@ -1,0 +1,29 @@
+package com.zerobase.oriticket.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Likes {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long likesId;
+
+//    @ManyToOne
+    private Long memberId;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Post salePost;
+}

--- a/src/main/java/com/zerobase/oriticket/domain/post/repository/LikesRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/repository/LikesRepository.java
@@ -1,0 +1,20 @@
+package com.zerobase.oriticket.domain.post.repository;
+
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.entity.Likes;
+import com.zerobase.oriticket.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+    boolean existsByMemberIdAndSalePost(Long memberId, Post salePost);
+
+    Optional<Likes> findBySalePost_SalePostIdAndMemberId(Long salePostId, Long memberId);
+
+    List<Likes> findAllByMemberIdAndSalePost_SaleStatusNotIn(Long memberId, List<SaleStatus> saleStatusList);
+}

--- a/src/main/java/com/zerobase/oriticket/domain/post/service/LikesService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/post/service/LikesService.java
@@ -1,0 +1,54 @@
+package com.zerobase.oriticket.domain.post.service;
+
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.dto.RegisterLikesRequest;
+import com.zerobase.oriticket.domain.post.entity.Likes;
+import com.zerobase.oriticket.domain.post.entity.Post;
+import com.zerobase.oriticket.domain.post.repository.LikesRepository;
+import com.zerobase.oriticket.domain.post.repository.PostRepository;
+import com.zerobase.oriticket.global.constants.PostExceptionStatus;
+import com.zerobase.oriticket.global.exception.impl.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LikesService {
+
+    private final LikesRepository likesRepository;
+    private final PostRepository postRepository;
+
+    public Likes register(Long salePostId, RegisterLikesRequest request) {
+        Post salePost = postRepository.findById(salePostId)
+                .orElseThrow(() -> new CustomException(PostExceptionStatus.SALE_POST_NOT_FOUND.getCode(),
+                        PostExceptionStatus.SALE_POST_NOT_FOUND.getMessage()));
+
+        validateCanRegister(request.getMemberId(), salePost);
+
+        return likesRepository.save(request.toEntity(salePost));
+    }
+
+    public Long delete(Long salePostId, Long memberId) {
+        Likes likes = likesRepository.findBySalePost_SalePostIdAndMemberId(salePostId, memberId)
+                .orElseThrow(() -> new CustomException(PostExceptionStatus.LIKES_NOT_FOUND.getCode(),
+                        PostExceptionStatus.LIKES_NOT_FOUND.getMessage()));
+
+        likesRepository.delete(likes);
+
+        return likes.getLikesId();
+    }
+
+    public List<Likes> get(Long memberId) {
+        List<SaleStatus> saleStatusList = List.of(SaleStatus.REPORTED);
+        return likesRepository.findAllByMemberIdAndSalePost_SaleStatusNotIn(memberId, saleStatusList);
+    }
+
+    private void validateCanRegister(Long memberId, Post salePost){
+        if(likesRepository.existsByMemberIdAndSalePost(memberId, salePost)){
+            throw new CustomException(PostExceptionStatus.CANNOT_REGISTER_LIKES_EXIST_LIKES.getCode(),
+                    PostExceptionStatus.CANNOT_REGISTER_LIKES_EXIST_LIKES.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/global/constants/PostExceptionStatus.java
+++ b/src/main/java/com/zerobase/oriticket/global/constants/PostExceptionStatus.java
@@ -12,6 +12,8 @@ public enum PostExceptionStatus {
     SPORTS_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "스포츠 정보를 찾을 수 없습니다."),
     STADIUM_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "경기장 정보를 찾을 수 없습니다."),
     AWAY_TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "팀 정보를 찾을 수 없습니다."),
+    LIKES_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "찜하기 정보를 찾을 수 없습니다."),
+    CANNOT_REGISTER_LIKES_EXIST_LIKES(HttpStatus.BAD_REQUEST.value(), "이미 등록된 찜하기 정보입니다. 찜하기 등록을 할 수 없습니다."),
     CANNOT_DELETE_POST_EXIST_TRANSACTION(HttpStatus.BAD_REQUEST.value(), "생성된 거래가 있습니다. 판매글을 삭제 할 수 없습니다."),
     CANNOT_DELETE_SPORTS_EXIST_TICKET(HttpStatus.BAD_REQUEST.value(), "생성된 티켓이 있습니다. 스포츠를 삭제할 수 없습니다."),
     CANNOT_DELETE_STADIUM_EXIST_TICKET(HttpStatus.BAD_REQUEST.value(), "생성된 티켓이 있습니다. 경기장을 삭제할 수 없습니다."),

--- a/src/main/java/com/zerobase/oriticket/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/zerobase/oriticket/global/exception/CustomExceptionHandler.java
@@ -1,38 +1,38 @@
-package com.zerobase.oriticket.global.exception;
-
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.TypeMismatchException;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-
-@ControllerAdvice
-@Slf4j
-public class CustomExceptionHandler {
-
-    @ExceptionHandler(AbstractException.class)
-    protected ResponseEntity<Void> handleCustomException(AbstractException e) {
-        log.error("CustomException..........");
-        log.error(e.getMessage());
-
-        return ResponseEntity.status(e.getErrorCode()).build();
-    }
-
-    @ExceptionHandler(TypeMismatchException.class)
-    protected ResponseEntity<Void> handleRuntimeException(TypeMismatchException e) {
-        log.error("TypeMismatchException..........");
-        log.error(e.getMessage());
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-    }
-
-    @ExceptionHandler(RuntimeException.class)
-    protected ResponseEntity<Void> handleRuntimeException(RuntimeException e) {
-        log.error("RuntimeException..........");
-        log.error(e.getMessage());
-
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
-
-}
+//package com.zerobase.oriticket.global.exception;
+//
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.TypeMismatchException;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.ControllerAdvice;
+//import org.springframework.web.bind.annotation.ExceptionHandler;
+//
+//@ControllerAdvice
+//@Slf4j
+//public class CustomExceptionHandler {
+//
+//    @ExceptionHandler(AbstractException.class)
+//    protected ResponseEntity<Void> handleCustomException(AbstractException e) {
+//        log.error("CustomException..........");
+//        log.error(e.getMessage());
+//
+//        return ResponseEntity.status(e.getErrorCode()).build();
+//    }
+//
+//    @ExceptionHandler(TypeMismatchException.class)
+//    protected ResponseEntity<Void> handleRuntimeException(TypeMismatchException e) {
+//        log.error("TypeMismatchException..........");
+//        log.error(e.getMessage());
+//
+//        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+//    }
+//
+//    @ExceptionHandler(RuntimeException.class)
+//    protected ResponseEntity<Void> handleRuntimeException(RuntimeException e) {
+//        log.error("RuntimeException..........");
+//        log.error(e.getMessage());
+//
+//        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+//    }
+//
+//}

--- a/src/main/java/com/zerobase/oriticket/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/zerobase/oriticket/global/exception/CustomExceptionHandler.java
@@ -1,38 +1,38 @@
-//package com.zerobase.oriticket.global.exception;
-//
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.beans.TypeMismatchException;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.ControllerAdvice;
-//import org.springframework.web.bind.annotation.ExceptionHandler;
-//
-//@ControllerAdvice
-//@Slf4j
-//public class CustomExceptionHandler {
-//
-//    @ExceptionHandler(AbstractException.class)
-//    protected ResponseEntity<Void> handleCustomException(AbstractException e) {
-//        log.error("CustomException..........");
-//        log.error(e.getMessage());
-//
-//        return ResponseEntity.status(e.getErrorCode()).build();
-//    }
-//
-//    @ExceptionHandler(TypeMismatchException.class)
-//    protected ResponseEntity<Void> handleRuntimeException(TypeMismatchException e) {
-//        log.error("TypeMismatchException..........");
-//        log.error(e.getMessage());
-//
-//        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-//    }
-//
-//    @ExceptionHandler(RuntimeException.class)
-//    protected ResponseEntity<Void> handleRuntimeException(RuntimeException e) {
-//        log.error("RuntimeException..........");
-//        log.error(e.getMessage());
-//
-//        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-//    }
-//
-//}
+package com.zerobase.oriticket.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(AbstractException.class)
+    protected ResponseEntity<Void> handleCustomException(AbstractException e) {
+        log.error("CustomException..........");
+        log.error(e.getMessage());
+
+        return ResponseEntity.status(e.getErrorCode()).build();
+    }
+
+    @ExceptionHandler(TypeMismatchException.class)
+    protected ResponseEntity<Void> handleRuntimeException(TypeMismatchException e) {
+        log.error("TypeMismatchException..........");
+        log.error(e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    protected ResponseEntity<Void> handleRuntimeException(RuntimeException e) {
+        log.error("RuntimeException..........");
+        log.error(e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+
+}

--- a/src/test/java/com/zerobase/oriticket/post/controller/AwayTeamControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/AwayTeamControllerTest.java
@@ -44,6 +44,21 @@ public class    AwayTeamControllerTest {
     private final static String SPORTS_NAME = "야구";
     private final static String AWAY_TEAM_NAME = "두산";
 
+    private Sports createSports(Long sportsId, String sportsName) {
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
     @Test
     @DisplayName("AwayTeam 등록 성공")
     void successRegister() throws Exception{
@@ -54,10 +69,7 @@ public class    AwayTeamControllerTest {
                         .awayTeamName(AWAY_TEAM_NAME)
                         .build();
 
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
 
         given(awayTeamService.register(any(RegisterAwayTeamRequest.class)))
                 .willReturn(AwayTeam.builder()
@@ -82,10 +94,7 @@ public class    AwayTeamControllerTest {
     @DisplayName("AwayTeam 조회 성공")
     void successGet() throws Exception{
         //given
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
 
         given(awayTeamService.get(anyLong()))
                 .willReturn(AwayTeam.builder()
@@ -108,30 +117,11 @@ public class    AwayTeamControllerTest {
     @DisplayName("AwayTeam 모두 조회 성공")
     void successGetAll() throws Exception{
         //given
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
 
-        AwayTeam awayTeam1 = AwayTeam.builder()
-                .awayTeamId(1L)
-                .sports(sports)
-                .awayTeamName("기아")
-                .build();
-
-        AwayTeam awayTeam2 = AwayTeam.builder()
-                .awayTeamId(2L)
-                .sports(sports)
-                .awayTeamName("한화")
-                .build();
-
-        AwayTeam awayTeam3 = AwayTeam.builder()
-                .awayTeamId(3L)
-                .sports(sports)
-                .awayTeamName("두산")
-                .build();
-
-
+        AwayTeam awayTeam1 = createAwayTeam(1L, sports, "기아");
+        AwayTeam awayTeam2 = createAwayTeam(2L, sports, "한화");
+        AwayTeam awayTeam3 = createAwayTeam(3L, sports, "두산");
 
         List<AwayTeam> awayTeamList
                 = Arrays.asList(awayTeam1, awayTeam2, awayTeam3);
@@ -160,16 +150,9 @@ public class    AwayTeamControllerTest {
     @DisplayName("SportId로 AwayTeam 조회 성공")
     void successGetBySportId() throws Exception{
         //given
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
 
-        AwayTeam awayTeam = AwayTeam.builder()
-                .awayTeamId(AWAY_TEAM_ID)
-                .sports(sports)
-                .awayTeamName(AWAY_TEAM_NAME)
-                .build();
+        AwayTeam awayTeam = createAwayTeam(AWAY_TEAM_ID, sports, AWAY_TEAM_NAME);
 
         List<AwayTeam> awayTeamList
                 = Arrays.asList(awayTeam);

--- a/src/test/java/com/zerobase/oriticket/post/controller/LikesControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/LikesControllerTest.java
@@ -1,0 +1,218 @@
+package com.zerobase.oriticket.post.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.oriticket.domain.post.controller.LikesController;
+import com.zerobase.oriticket.domain.post.dto.RegisterLikesRequest;
+import com.zerobase.oriticket.domain.post.entity.*;
+import com.zerobase.oriticket.domain.post.service.LikesService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LikesController.class)
+public class LikesControllerTest {
+
+    @MockBean
+    private LikesService likesService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 15000;
+    private final static Boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "A열 4석";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Ticket ticket){
+        return Post.builder()
+                .salePostId(salePostId)
+                .ticket(ticket)
+                .build();
+    }
+
+    private Likes createLikes(Long likesId, Long memberId, Post salePost){
+        return Likes.builder()
+                .likesId(likesId)
+                .memberId(memberId)
+                .salePost(salePost)
+                .build();
+    }
+
+    @Test
+    @DisplayName("찜하기에 등록 완료")
+    void successRegister() throws Exception {
+        //given
+        RegisterLikesRequest registerRequest = RegisterLikesRequest.builder()
+                .memberId(1L)
+                .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket = createTicket(12L, sports, stadium, awayTeam);
+        Post salePost = createPost(50L, ticket);
+        Likes likes = createLikes(1L, 10L, salePost);
+
+        given(likesService.register(anyLong(), any(RegisterLikesRequest.class)))
+                .willReturn(likes);
+
+        //when
+        //then
+        mockMvc.perform(post("/posts/1/likes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registerRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.likesId").value(1L))
+                .andExpect(jsonPath("$.memberId").value(10L))
+                .andExpect(jsonPath("$.salePost.salePostId").value(50L))
+                .andExpect(jsonPath("$.salePost.ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.salePost.ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.salePost.ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.salePost.ticket.awayTeamName").value("한화"))
+                .andExpect(jsonPath("$.salePost.ticket.quantity").value(1))
+                .andExpect(jsonPath("$.salePost.ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.salePost.ticket.originalPrice").value(15000))
+                .andExpect(jsonPath("$.salePost.ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.salePost.ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.salePost.ticket.seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.salePost.ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.salePost.ticket.note").value("note"));
+
+    }
+
+    @Test
+    @DisplayName("찜하기에서 삭제 완료")
+    void successDelete() throws Exception {
+        //given
+        given(likesService.delete(anyLong(), anyLong()))
+                .willReturn(1L);
+
+        //when
+        //then
+        mockMvc.perform(delete("/posts/1/likes?memberId=1"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(1));
+
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 모든 찜하기 조회 완료")
+    void successGet() throws Exception {
+        //given
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket1 = createTicket(12L, sports, stadium, awayTeam);
+        Ticket ticket2 = createTicket(13L, sports, stadium, awayTeam);
+        Post salePost1 = createPost(50L, ticket1);
+        Post salePost2 = createPost(51L, ticket2);
+        Likes likes1 = createLikes(1L, 10L, salePost1);
+        Likes likes2 = createLikes(2L, 10L, salePost2);
+
+        List<Likes> likesList = Arrays.asList(likes1, likes2);
+
+        given(likesService.get(anyLong()))
+                .willReturn(likesList);
+
+        //when
+        //then
+        mockMvc.perform(get("/members/10/likes"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.[0].likesId").value(1L))
+                .andExpect(jsonPath("$.[0].memberId").value(10L))
+                .andExpect(jsonPath("$.[0].salePost.salePostId").value(50L))
+                .andExpect(jsonPath("$.[0].salePost.ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.[0].salePost.ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.[0].salePost.ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.[0].salePost.ticket.awayTeamName").value("한화"))
+                .andExpect(jsonPath("$.[0].salePost.ticket.quantity").value(1))
+                .andExpect(jsonPath("$.[0].salePost.ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.[0].salePost.ticket.originalPrice").value(15000))
+                .andExpect(jsonPath("$.[0].salePost.ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.[0].salePost.ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.[0].salePost.ticket.seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.[0].salePost.ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.[0].salePost.ticket.note").value("note"))
+                .andExpect(jsonPath("$.[1].likesId").value(2L))
+                .andExpect(jsonPath("$.[1].memberId").value(10L))
+                .andExpect(jsonPath("$.[1].salePost.salePostId").value(51L))
+                .andExpect(jsonPath("$.[1].salePost.ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.[1].salePost.ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.[1].salePost.ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.[1].salePost.ticket.awayTeamName").value("한화"))
+                .andExpect(jsonPath("$.[1].salePost.ticket.quantity").value(1))
+                .andExpect(jsonPath("$.[1].salePost.ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.[1].salePost.ticket.originalPrice").value(15000))
+                .andExpect(jsonPath("$.[1].salePost.ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.[1].salePost.ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.[1].salePost.ticket.seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.[1].salePost.ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.[1].salePost.ticket.note").value("note"));
+
+    }
+}

--- a/src/test/java/com/zerobase/oriticket/post/controller/PostControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/PostControllerTest.java
@@ -56,8 +56,59 @@ public class PostControllerTest {
 
     private final static String SPORTS_NAME = "야구";
     private final static String STADIUM_NAME = "고척돔";
-    private final static String HOME_TEAM_NAME = "두산";
+    private final static String HOME_TEAM_NAME = "키움";
     private final static String AWAY_TEAM_NAME = "한화";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Long memberId, Ticket ticket, SaleStatus status){
+        return Post.builder()
+                .salePostId(salePostId)
+                .memberId(memberId)
+                .ticket(ticket)
+                .saleStatus(status)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 
     @Test
     @DisplayName("SalePost 등록 성공")
@@ -78,48 +129,14 @@ public class PostControllerTest {
                         .imgUrl(IMG_URL)
                         .note(NOTE)
                         .build();
-
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
-
-        Stadium stadium = Stadium.builder()
-                .stadiumId(STADIUM_ID)
-                .sports(sports)
-                .stadiumName(STADIUM_NAME)
-                .homeTeamName(HOME_TEAM_NAME)
-                .build();
-
-        AwayTeam awayTeam = AwayTeam.builder()
-                .awayTeamId(AWAY_TEAM_ID)
-                .sports(sports)
-                .awayTeamName(AWAY_TEAM_NAME)
-                .build();
-
-        Ticket ticket = Ticket.builder()
-                .ticketId(TICKET_ID)
-                .sports(sports)
-                .stadium(stadium)
-                .awayTeam(awayTeam)
-                .quantity(QUANTITY)
-                .salePrice(SALE_PRICE)
-                .originalPrice(ORIGINAL_PRICE)
-                .expirationAt(EXPIRATION_AT)
-                .isSuccessive(IS_SUCCESSIVE)
-                .seatInfo(SEAT_INFO)
-                .imgUrl(IMG_URL)
-                .note(NOTE)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
+        Stadium stadium = createStadium(STADIUM_ID, sports, STADIUM_NAME, HOME_TEAM_NAME);
+        AwayTeam awayTeam = createAwayTeam(AWAY_TEAM_ID, sports, AWAY_TEAM_NAME);
+        Ticket ticket = createTicket(TICKET_ID, sports, stadium, awayTeam);
+        Post salePost = createPost(SALE_POST_ID, MEMBER_ID, ticket, SaleStatus.FOR_SALE);
 
         given(postService.registerPost(any(RegisterPostRequest.class)))
-                .willReturn(Post.builder()
-                        .salePostId(SALE_POST_ID)
-                        .memberId(MEMBER_ID)
-                        .ticket(ticket)
-                        .saleStatus(SaleStatus.FOR_SALE)
-                        .createdAt(LocalDateTime.now())
-                        .build());
+                .willReturn(salePost);
         //when
         //then
         mockMvc.perform(post(BASE_URL)
@@ -129,9 +146,10 @@ public class PostControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.salePostId").value(1L))
                 .andExpect(jsonPath("$.memberId").value(1L))
-                .andExpect(jsonPath("$.ticket.sportsId").value(1L))
-                .andExpect(jsonPath("$.ticket.stadiumId").value(1L))
-                .andExpect(jsonPath("$.ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.ticket.awayTeamName").value("한화"))
                 .andExpect(jsonPath("$.ticket.quantity").value(1))
                 .andExpect(jsonPath("$.ticket.salePrice").value(10000))
                 .andExpect(jsonPath("$.ticket.originalPrice").value(20000))
@@ -146,47 +164,14 @@ public class PostControllerTest {
     @DisplayName("SalePost 조회 성공")
     void successGet() throws Exception {
         //given
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
-
-        Stadium stadium = Stadium.builder()
-                .stadiumId(STADIUM_ID)
-                .sports(sports)
-                .stadiumName(STADIUM_NAME)
-                .homeTeamName(HOME_TEAM_NAME)
-                .build();
-
-        AwayTeam awayTeam = AwayTeam.builder()
-                .awayTeamId(AWAY_TEAM_ID)
-                .sports(sports)
-                .awayTeamName(AWAY_TEAM_NAME)
-                .build();
-
-        Ticket ticket = Ticket.builder()
-                .ticketId(TICKET_ID)
-                .sports(sports)
-                .stadium(stadium)
-                .awayTeam(awayTeam)
-                .quantity(QUANTITY)
-                .salePrice(SALE_PRICE)
-                .originalPrice(ORIGINAL_PRICE)
-                .expirationAt(EXPIRATION_AT)
-                .isSuccessive(IS_SUCCESSIVE)
-                .seatInfo(SEAT_INFO)
-                .imgUrl(IMG_URL)
-                .note(NOTE)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
+        Stadium stadium = createStadium(STADIUM_ID, sports, STADIUM_NAME, HOME_TEAM_NAME);
+        AwayTeam awayTeam = createAwayTeam(AWAY_TEAM_ID, sports, AWAY_TEAM_NAME);
+        Ticket ticket = createTicket(TICKET_ID, sports, stadium, awayTeam);
+        Post salePost = createPost(SALE_POST_ID, MEMBER_ID, ticket, SaleStatus.FOR_SALE);
 
         given(postService.get(anyLong()))
-                .willReturn(Post.builder()
-                        .salePostId(SALE_POST_ID)
-                        .memberId(MEMBER_ID)
-                        .ticket(ticket)
-                        .saleStatus(SaleStatus.FOR_SALE)
-                        .createdAt(LocalDateTime.now())
-                        .build());
+                .willReturn(salePost);
 
         //when
         //then
@@ -195,9 +180,10 @@ public class PostControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.salePostId").value(1L))
                 .andExpect(jsonPath("$.memberId").value(1L))
-                .andExpect(jsonPath("$.ticket.sportsId").value(1L))
-                .andExpect(jsonPath("$.ticket.stadiumId").value(1L))
-                .andExpect(jsonPath("$.ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.ticket.awayTeamName").value("한화"))
                 .andExpect(jsonPath("$.ticket.quantity").value(1))
                 .andExpect(jsonPath("$.ticket.salePrice").value(10000))
                 .andExpect(jsonPath("$.ticket.originalPrice").value(20000))
@@ -231,48 +217,14 @@ public class PostControllerTest {
                 UpdateStatusToReportedPostRequest.builder()
                         .salePostId(SALE_POST_ID)
                         .build();
-
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
-
-        Stadium stadium = Stadium.builder()
-                .stadiumId(STADIUM_ID)
-                .sports(sports)
-                .stadiumName(STADIUM_NAME)
-                .homeTeamName(HOME_TEAM_NAME)
-                .build();
-
-        AwayTeam awayTeam = AwayTeam.builder()
-                .awayTeamId(AWAY_TEAM_ID)
-                .sports(sports)
-                .awayTeamName(AWAY_TEAM_NAME)
-                .build();
-
-        Ticket ticket = Ticket.builder()
-                .ticketId(TICKET_ID)
-                .sports(sports)
-                .stadium(stadium)
-                .awayTeam(awayTeam)
-                .quantity(QUANTITY)
-                .salePrice(SALE_PRICE)
-                .originalPrice(ORIGINAL_PRICE)
-                .expirationAt(EXPIRATION_AT)
-                .isSuccessive(IS_SUCCESSIVE)
-                .seatInfo(SEAT_INFO)
-                .imgUrl(IMG_URL)
-                .note(NOTE)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
+        Stadium stadium = createStadium(STADIUM_ID, sports, STADIUM_NAME, HOME_TEAM_NAME);
+        AwayTeam awayTeam = createAwayTeam(AWAY_TEAM_ID, sports, AWAY_TEAM_NAME);
+        Ticket ticket = createTicket(TICKET_ID, sports, stadium, awayTeam);
+        Post salePost = createPost(SALE_POST_ID, MEMBER_ID, ticket, SaleStatus.REPORTED);
 
         given(postService.updateToReported(any(UpdateStatusToReportedPostRequest.class)))
-                .willReturn(Post.builder()
-                        .salePostId(SALE_POST_ID)
-                        .memberId(MEMBER_ID)
-                        .ticket(ticket)
-                        .saleStatus(SaleStatus.REPORTED)
-                        .createdAt(LocalDateTime.now())
-                        .build());
+                .willReturn(salePost);
 
         //when
         //then
@@ -283,9 +235,10 @@ public class PostControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.salePostId").value(1L))
                 .andExpect(jsonPath("$.memberId").value(1L))
-                .andExpect(jsonPath("$.ticket.sportsId").value(1L))
-                .andExpect(jsonPath("$.ticket.stadiumId").value(1L))
-                .andExpect(jsonPath("$.ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.ticket.awayTeamName").value("한화"))
                 .andExpect(jsonPath("$.ticket.quantity").value(1))
                 .andExpect(jsonPath("$.ticket.salePrice").value(10000))
                 .andExpect(jsonPath("$.ticket.originalPrice").value(20000))

--- a/src/test/java/com/zerobase/oriticket/post/controller/PostFetchControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/PostFetchControllerTest.java
@@ -15,8 +15,8 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -104,7 +104,7 @@ public class PostFetchControllerTest {
         Post post2 = createPost(2L, 1L, SaleStatus.TRADING, ticket2);
         List<Post> postList = Arrays.asList(post1, post2);
 
-        given(postFetchService.get(anyLong(), any(List.class)))
+        given(postFetchService.get(anyLong(), anyList()))
                 .willReturn(postList);
 
         //when
@@ -114,9 +114,10 @@ public class PostFetchControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.[0].salePostId").value(1L))
                 .andExpect(jsonPath("$.[0].memberId").value(1L))
-                .andExpect(jsonPath("$.[0].ticket.sportsId").value(1L))
-                .andExpect(jsonPath("$.[0].ticket.stadiumId").value(1L))
-                .andExpect(jsonPath("$.[0].ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.[0].ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.[0].ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.[0].ticket.awayTeamName").value("한화"))
                 .andExpect(jsonPath("$.[0].ticket.quantity").value(1))
                 .andExpect(jsonPath("$.[0].ticket.salePrice").value(10000))
                 .andExpect(jsonPath("$.[0].ticket.originalPrice").value(15000))
@@ -129,9 +130,10 @@ public class PostFetchControllerTest {
                 .andExpect(jsonPath("$.[0].createdAt").exists())
                 .andExpect(jsonPath("$.[1].salePostId").value(2L))
                 .andExpect(jsonPath("$.[1].memberId").value(1L))
-                .andExpect(jsonPath("$.[1].ticket.sportsId").value(1L))
-                .andExpect(jsonPath("$.[1].ticket.stadiumId").value(1L))
-                .andExpect(jsonPath("$.[1].ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.[1].ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.[1].ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.[1].ticket.awayTeamName").value("한화"))
                 .andExpect(jsonPath("$.[1].ticket.quantity").value(1))
                 .andExpect(jsonPath("$.[1].ticket.salePrice").value(10000))
                 .andExpect(jsonPath("$.[1].ticket.originalPrice").value(15000))
@@ -157,7 +159,7 @@ public class PostFetchControllerTest {
         Post post2 = createPost(2L, 1L, SaleStatus.REPORTED, ticket2);
         List<Post> postList = Arrays.asList(post1, post2);
 
-        given(postFetchService.get(anyLong(), any(List.class)))
+        given(postFetchService.get(anyLong(), anyList()))
                 .willReturn(postList);
 
         //when
@@ -167,9 +169,10 @@ public class PostFetchControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.[0].salePostId").value(1L))
                 .andExpect(jsonPath("$.[0].memberId").value(1L))
-                .andExpect(jsonPath("$.[0].ticket.sportsId").value(1L))
-                .andExpect(jsonPath("$.[0].ticket.stadiumId").value(1L))
-                .andExpect(jsonPath("$.[0].ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.[0].ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.[0].ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.[0].ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.[0].ticket.awayTeamName").value("한화"))
                 .andExpect(jsonPath("$.[0].ticket.quantity").value(1))
                 .andExpect(jsonPath("$.[0].ticket.salePrice").value(10000))
                 .andExpect(jsonPath("$.[0].ticket.originalPrice").value(15000))
@@ -182,9 +185,10 @@ public class PostFetchControllerTest {
                 .andExpect(jsonPath("$.[0].createdAt").exists())
                 .andExpect(jsonPath("$.[1].salePostId").value(2L))
                 .andExpect(jsonPath("$.[1].memberId").value(1L))
-                .andExpect(jsonPath("$.[1].ticket.sportsId").value(1L))
-                .andExpect(jsonPath("$.[1].ticket.stadiumId").value(1L))
-                .andExpect(jsonPath("$.[1].ticket.awayTeamId").value(1L))
+                .andExpect(jsonPath("$.[1].ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.[1].ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.[1].ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.[1].ticket.awayTeamName").value("한화"))
                 .andExpect(jsonPath("$.[1].ticket.quantity").value(1))
                 .andExpect(jsonPath("$.[1].ticket.salePrice").value(10000))
                 .andExpect(jsonPath("$.[1].ticket.originalPrice").value(15000))

--- a/src/test/java/com/zerobase/oriticket/post/controller/PostSearchControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/PostSearchControllerTest.java
@@ -36,53 +36,54 @@ public class PostSearchControllerTest {
 
     private final static String BASE_URL = "/posts";
 
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 15000;
+    private final static Boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "A열 4석";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private PostSearchDocument createPostDocument(
+            Long salePostId,
+            String memberName,
+            String sportsName,
+            String stadiumName,
+            String homeTeamName,
+            String awayTeamName
+    ){
+        return PostSearchDocument.builder()
+                .salePostId(salePostId)
+                .memberName(memberName)
+                .sportsName(sportsName)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .awayTeamName(awayTeamName)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(1))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .saleStatus(SaleStatus.FOR_SALE)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
     @Test
     @DisplayName("SalePost 검색 성공")
     void successSearch() throws Exception {
         //given
         PostSearchDocument postSearchDocument1 =
-                PostSearchDocument.builder()
-                        .salePostId(1L)
-                        .memberName("member1")
-                        .sportsName("야구")
-                        .stadiumName("잠실 경기장")
-                        .homeTeamName("두산")
-                        .awayTeamName("기아")
-                        .quantity(1)
-                        .salePrice(10000)
-                        .originalPrice(15000)
-                        .expirationAt(LocalDateTime.now().plusDays(1))
-                        .isSuccessive(false)
-                        .seatInfo("A열 21")
-                        .imgUrl("image url1")
-                        .note("note1")
-                        .saleStatus(SaleStatus.FOR_SALE)
-                        .createdAt(LocalDateTime.now())
-                        .build();
-
+                createPostDocument(1L, "member1", "야구",
+                        "잠실 경기장", "두산", "기아");
         PostSearchDocument postSearchDocument2 =
-                PostSearchDocument.builder()
-                        .salePostId(2L)
-                        .memberName("member2")
-                        .sportsName("야구")
-                        .stadiumName("잠실 경기장")
-                        .homeTeamName("두산")
-                        .awayTeamName("한화")
-                        .quantity(1)
-                        .salePrice(15000)
-                        .originalPrice(20000)
-                        .expirationAt(LocalDateTime.now().plusDays(2))
-                        .isSuccessive(false)
-                        .seatInfo("C열 21")
-                        .imgUrl("image url2")
-                        .note("note2")
-                        .saleStatus(SaleStatus.FOR_SALE)
-                        .createdAt(LocalDateTime.now())
-                        .build();
-
+                createPostDocument(2L, "member2", "야구",
+                        "잠실 경기장", "두산", "한화");
         List<PostSearchDocument> postSearchDocumentList =
                 Arrays.asList(postSearchDocument1, postSearchDocument2);
-
         Page<PostSearchDocument> postSearchDocuments =
                 new PageImpl<>(postSearchDocumentList);
 
@@ -105,9 +106,9 @@ public class PostSearchControllerTest {
                 .andExpect(jsonPath("$.content[0].originalPrice").value(15000))
                 .andExpect(jsonPath("$.content[0].expirationAt").exists())
                 .andExpect(jsonPath("$.content[0].isSuccessive").value(false))
-                .andExpect(jsonPath("$.content[0].seatInfo").value("A열 21"))
-                .andExpect(jsonPath("$.content[0].imgUrl").value("image url1"))
-                .andExpect(jsonPath("$.content[0].note").value("note1"))
+                .andExpect(jsonPath("$.content[0].seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.content[0].imgUrl").value("image url"))
+                .andExpect(jsonPath("$.content[0].note").value("note"))
                 .andExpect(jsonPath("$.content[0].saleStatus").value("FOR_SALE"))
                 .andExpect(jsonPath("$.content[0].createdAt").exists())
                 .andExpect(jsonPath("$.content[1].salePostId").value(2L))
@@ -117,13 +118,13 @@ public class PostSearchControllerTest {
                 .andExpect(jsonPath("$.content[1].homeTeamName").value("두산"))
                 .andExpect(jsonPath("$.content[1].awayTeamName").value("한화"))
                 .andExpect(jsonPath("$.content[1].quantity").value(1))
-                .andExpect(jsonPath("$.content[1].salePrice").value(15000))
-                .andExpect(jsonPath("$.content[1].originalPrice").value(20000))
+                .andExpect(jsonPath("$.content[1].salePrice").value(10000))
+                .andExpect(jsonPath("$.content[1].originalPrice").value(15000))
                 .andExpect(jsonPath("$.content[1].expirationAt").exists())
                 .andExpect(jsonPath("$.content[1].isSuccessive").value(false))
-                .andExpect(jsonPath("$.content[1].seatInfo").value("C열 21"))
-                .andExpect(jsonPath("$.content[1].imgUrl").value("image url2"))
-                .andExpect(jsonPath("$.content[1].note").value("note2"))
+                .andExpect(jsonPath("$.content[1].seatInfo").value("A열 4석"))
+                .andExpect(jsonPath("$.content[1].imgUrl").value("image url"))
+                .andExpect(jsonPath("$.content[1].note").value("note"))
                 .andExpect(jsonPath("$.content[1].saleStatus").value("FOR_SALE"))
                 .andExpect(jsonPath("$.content[1].createdAt").exists());
 

--- a/src/test/java/com/zerobase/oriticket/post/controller/SportsControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/SportsControllerTest.java
@@ -41,6 +41,13 @@ public class SportsControllerTest {
     private final static Long SPORTS_ID = 1L;
     private final static String SPORTS_NAME = "야구";
 
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
     @Test
     @DisplayName("Sports 등록 성공")
     void successRegister() throws Exception{
@@ -49,12 +56,10 @@ public class SportsControllerTest {
                 RegisterSportsRequest.builder()
                         .sportsName(SPORTS_NAME)
                         .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
 
         given(sportsService.register(any(RegisterSportsRequest.class)))
-                .willReturn(Sports.builder()
-                        .sportsId(SPORTS_ID)
-                        .sportsName(SPORTS_NAME)
-                        .build());
+                .willReturn(sports);
 
         //when
         //then
@@ -71,11 +76,10 @@ public class SportsControllerTest {
     @DisplayName("Sports 조회 성공")
     void successGet() throws Exception{
         //given
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
+
         given(sportsService.get(anyLong()))
-                .willReturn(Sports.builder()
-                        .sportsId(SPORTS_ID)
-                        .sportsName(SPORTS_NAME)
-                        .build());
+                .willReturn(sports);
 
         //when
         //then
@@ -90,21 +94,9 @@ public class SportsControllerTest {
     @DisplayName("Sports 모두 조회 성공")
     void successGetAll() throws Exception{
         //given
-        Sports sports1 = Sports.builder()
-                .sportsId(1L)
-                .sportsName("야구")
-                .build();
-
-        Sports sports2 = Sports.builder()
-                .sportsId(2L)
-                .sportsName("축구")
-                .build();
-
-        Sports sports3 = Sports.builder()
-                .sportsId(3L)
-                .sportsName("농구")
-                .build();
-
+        Sports sports1 = createSports(1L, "야구");
+        Sports sports2 = createSports(2L, "축구");
+        Sports sports3 = createSports(3L, "농구");
         List<Sports> sportsList 
                 = Arrays.asList(sports1, sports2, sports3);
 

--- a/src/test/java/com/zerobase/oriticket/post/controller/StadiumControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/StadiumControllerTest.java
@@ -45,6 +45,22 @@ public class StadiumControllerTest {
     private final static String STADIUM_NAME = "고척 돔";
     private final static String HOME_TEAM_NAME = "한화";
 
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
     @Test
     @DisplayName("Stadium 등록 성공")
     void successRegister() throws Exception{
@@ -55,19 +71,11 @@ public class StadiumControllerTest {
                         .stadiumName(STADIUM_NAME)
                         .homeTeamName(HOME_TEAM_NAME)
                         .build();
-        
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
-        
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
+        Stadium stadium = createStadium(STADIUM_ID, sports, STADIUM_NAME, HOME_TEAM_NAME);
+
         given(stadiumService.register(any(RegisterStadiumRequest.class)))
-                .willReturn(Stadium.builder()
-                        .stadiumId(STADIUM_ID)
-                        .sports(sports)
-                        .stadiumName(STADIUM_NAME)
-                        .homeTeamName(HOME_TEAM_NAME)
-                        .build());
+                .willReturn(stadium);
 
         //when
         //then
@@ -86,18 +94,11 @@ public class StadiumControllerTest {
     @DisplayName("Stadium 조회 성공")
     void successGet() throws Exception{
         //given
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
+        Stadium stadium = createStadium(STADIUM_ID, sports, STADIUM_NAME, HOME_TEAM_NAME);
 
         given(stadiumService.get(anyLong()))
-                .willReturn(Stadium.builder()
-                        .stadiumId(STADIUM_ID)
-                        .sports(sports)
-                        .stadiumName(STADIUM_NAME)
-                        .homeTeamName(HOME_TEAM_NAME)
-                        .build());
+                .willReturn(stadium);
 
         //when
         //then
@@ -114,33 +115,10 @@ public class StadiumControllerTest {
     @DisplayName("Stadium 모두 조회 성공")
     void successGetAll() throws Exception{
         //given
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
-
-        Stadium stadium1 = Stadium.builder()
-                .stadiumId(1L)
-                .sports(sports)
-                .stadiumName("고척 돔")
-                .homeTeamName("한화")
-                .build();
-
-        Stadium stadium2 = Stadium.builder()
-                .stadiumId(2L)
-                .sports(sports)
-                .stadiumName("잠실 야구장")
-                .homeTeamName("두산")
-                .build();
-
-        Stadium stadium3 = Stadium.builder()
-                .stadiumId(3L)
-                .sports(sports)
-                .stadiumName("챔피언스 필드")
-                .homeTeamName("기아")
-                .build();
-
-
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
+        Stadium stadium1 = createStadium(1L, sports, "고척 돔", "한화");
+        Stadium stadium2 = createStadium(1L, sports, "잠실 야구장", "두산");
+        Stadium stadium3 = createStadium(1L, sports, "챔피언스 필드", "기아");
         List<Stadium> stadiumList
                 = Arrays.asList(stadium1, stadium2, stadium3);
 
@@ -171,20 +149,10 @@ public class StadiumControllerTest {
     @DisplayName("SportId로 Stadium 조회 성공")
     void successGetBySportId() throws Exception{
         //given
-        Sports sports = Sports.builder()
-                .sportsId(SPORTS_ID)
-                .sportsName(SPORTS_NAME)
-                .build();
+        Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
+        Stadium stadium = createStadium(STADIUM_ID, sports, STADIUM_NAME, HOME_TEAM_NAME);
 
-        Stadium stadium = Stadium.builder()
-                .stadiumId(STADIUM_ID)
-                .sports(sports)
-                .stadiumName(STADIUM_NAME)
-                .homeTeamName(HOME_TEAM_NAME)
-                .build();
-
-        List<Stadium> stadiumList
-                = Arrays.asList(stadium);
+        List<Stadium> stadiumList = List.of(stadium);
 
         given(stadiumService.getBySportsId(SPORTS_ID))
                 .willReturn(stadiumList);

--- a/src/test/java/com/zerobase/oriticket/post/service/LikesServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/service/LikesServiceTest.java
@@ -1,0 +1,180 @@
+package com.zerobase.oriticket.post.service;
+
+import com.zerobase.oriticket.domain.post.dto.RegisterLikesRequest;
+import com.zerobase.oriticket.domain.post.entity.*;
+import com.zerobase.oriticket.domain.post.repository.LikesRepository;
+import com.zerobase.oriticket.domain.post.repository.PostRepository;
+import com.zerobase.oriticket.domain.post.service.LikesService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class LikesServiceTest {
+
+    @Mock
+    private LikesRepository likesRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private LikesService likesService;
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 15000;
+    private final static Boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "A열 4석";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Ticket ticket){
+        return Post.builder()
+                .salePostId(salePostId)
+                .ticket(ticket)
+                .build();
+    }
+
+    private Likes createLikes(Long likesId, Long memberId, Post salePost){
+        return Likes.builder()
+                .likesId(likesId)
+                .memberId(memberId)
+                .salePost(salePost)
+                .build();
+    }
+
+    @Test
+    @DisplayName("찜하기에 등록 완료")
+    void successRegister(){
+        //given
+        RegisterLikesRequest registerRequest = RegisterLikesRequest.builder()
+                .memberId(1L)
+                .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket = createTicket(12L, sports, stadium, awayTeam);
+        Post salePost = createPost(50L, ticket);
+        Likes likes = createLikes(1L, 10L, salePost);
+
+        given(postRepository.findById(anyLong()))
+                .willReturn(Optional.of(salePost));
+        given(likesRepository.existsByMemberIdAndSalePost(anyLong(), any(Post.class)))
+                .willReturn(false);
+        given(likesRepository.save(any(Likes.class)))
+                .willReturn(likes);
+
+        //when
+        Likes fetchedLikes = likesService.register(50L, registerRequest);
+
+        //then
+        assertThat(fetchedLikes.getLikesId()).isEqualTo(1L);
+        assertThat(fetchedLikes.getMemberId()).isEqualTo(10L);
+        assertThat(fetchedLikes.getSalePost()).isEqualTo(salePost);
+    }
+
+    @Test
+    @DisplayName("찜하기에서 삭제 완료")
+    void successDelete(){
+        //given
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket = createTicket(12L, sports, stadium, awayTeam);
+        Post salePost = createPost(50L, ticket);
+        Likes likes = createLikes(1L, 10L, salePost);
+
+        given(likesRepository.findBySalePost_SalePostIdAndMemberId(anyLong(), anyLong()))
+                .willReturn(Optional.of(likes));
+
+        //when
+        Long fetchedLikesId = likesService.delete(1L, 10L);
+
+        //then
+        assertThat(fetchedLikesId).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 모든 찜하기 조회 완료")
+    void successGet(){
+        //given
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "한화");
+        Ticket ticket1 = createTicket(12L, sports, stadium, awayTeam);
+        Ticket ticket2 = createTicket(13L, sports, stadium, awayTeam);
+        Post salePost1 = createPost(50L, ticket1);
+        Post salePost2 = createPost(51L, ticket2);
+        Likes likes1 = createLikes(1L, 10L, salePost1);
+        Likes likes2 = createLikes(2L, 10L, salePost2);
+        List<Likes> likesList = Arrays.asList(likes1, likes2);
+
+        given(likesRepository.findAllByMemberIdAndSalePost_SaleStatusNotIn(anyLong(), anyList()))
+                .willReturn(likesList);
+
+        //when
+        List<Likes> fetchedLikes = likesService.get(10L);
+
+        //then
+        assertThat(fetchedLikes.get(0).getLikesId()).isEqualTo(1L);
+        assertThat(fetchedLikes.get(0).getMemberId()).isEqualTo(10L);
+        assertThat(fetchedLikes.get(0).getSalePost()).isEqualTo(salePost1);
+        assertThat(fetchedLikes.get(1).getLikesId()).isEqualTo(2L);
+        assertThat(fetchedLikes.get(1).getMemberId()).isEqualTo(10L);
+        assertThat(fetchedLikes.get(1).getSalePost()).isEqualTo(salePost2);
+    }
+}

--- a/src/test/java/com/zerobase/oriticket/post/service/PostFetchServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/service/PostFetchServiceTest.java
@@ -17,8 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -103,7 +102,7 @@ public class PostFetchServiceTest {
         Post post2 = createPost(2L, 1L, SaleStatus.TRADING, ticket2);
         List<Post> postList = Arrays.asList(post1, post2);
 
-        given(postRepository.findAllByMemberIdAndSaleStatusIn(anyLong(), any(List.class)))
+        given(postRepository.findAllByMemberIdAndSaleStatusIn(anyLong(), anyList()))
                 .willReturn(postList);
 
         //when
@@ -158,7 +157,7 @@ public class PostFetchServiceTest {
         Post post2 = createPost(2L, 1L, SaleStatus.REPORTED, ticket2);
         List<Post> postList = Arrays.asList(post1, post2);
 
-        given(postRepository.findAllByMemberIdAndSaleStatusIn(anyLong(), any(List.class)))
+        given(postRepository.findAllByMemberIdAndSaleStatusIn(anyLong(), anyList()))
                 .willReturn(postList);
 
         //when

--- a/src/test/java/com/zerobase/oriticket/transaction/controller/TransactionFetchControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/transaction/controller/TransactionFetchControllerTest.java
@@ -16,8 +16,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -74,7 +73,7 @@ public class TransactionFetchControllerTest {
 
         List<Transaction> transactionList = Arrays.asList(transaction1, transaction2);
 
-        given(transactionFetchService.get(anyLong(), any(List.class)))
+        given(transactionFetchService.get(anyLong(), anyList()))
                 .willReturn(transactionList);
 
         //when
@@ -117,7 +116,7 @@ public class TransactionFetchControllerTest {
 
         List<Transaction> transactionList = Arrays.asList(transaction1, transaction2);
 
-        given(transactionFetchService.get(anyLong(), any(List.class)))
+        given(transactionFetchService.get(anyLong(), anyList()))
                 .willReturn(transactionList);
 
         //when

--- a/src/test/java/com/zerobase/oriticket/transaction/service/TransactionFetchServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/transaction/service/TransactionFetchServiceTest.java
@@ -19,8 +19,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,7 +74,7 @@ public class TransactionFetchServiceTest {
         List<TransactionStatus> transactionStatusList =
                 Arrays.asList(TransactionStatus.PENDING, TransactionStatus.RECEIVED);
 
-        given(transactionRepository.findAllBySellerOrBuyerIdAndStatusList(anyLong(), any(List.class)))
+        given(transactionRepository.findAllBySellerOrBuyerIdAndStatusList(anyLong(), anyList()))
                 .willReturn(transactionList);
 
         //when
@@ -117,7 +116,7 @@ public class TransactionFetchServiceTest {
         List<TransactionStatus> transactionStatusList =
                 Arrays.asList(TransactionStatus.COMPLETED, TransactionStatus.CANCELED);
 
-        given(transactionRepository.findAllBySellerOrBuyerIdAndStatusList(anyLong(), any(List.class)))
+        given(transactionRepository.findAllBySellerOrBuyerIdAndStatusList(anyLong(), anyList()))
                 .willReturn(transactionList);
 
         //when


### PR DESCRIPTION
## 변경사항

### Post
- PostResponse 에서 나타냈던 티켓 정보중 Sports. Stadium, AwayTeam의 대한 정보를 Id가 아닌 Name을 보여주게 수정
    - SportsId -> SportsName
    - StadiumId -> StadiumName, HomeTeamName
    - AwayTeamId -> AwayTeamName

#### Likes
- 판매 글을 찜할 수 있는 기능 추가
- 찜한 판매글을 찜 목록에서 제거하는 기능 추가
- 특정 멤버 본인의 찜 목록을 조회하는 기능 추가
    - Reported 상태의 글을 제외하고 조회 가능
- 찜하기 기능과 관련된 예외 상태 2가지 추가
    - LIKES_NOT_FOUND : 찜한 정보를 찾을수 없음
    - CANNOT_REGISTER_LIKES_EXIST_LIKES : 같은 판매글을 같은 멤버가 찜하기를 중복 등록했을 시

### 기타
- 테스트 코드들의 중복되는 entity 객체 생성 코드를 create 메서드로 대체

## 변경 예정
- Member 기능 개발 완료시 Post, Transaction에 Member 연동 예정

## 테스트
- [x] 테스트 코드
- [x] API 테스트