### PR TITLE
Feature/report

### DIFF
--- a/src/main/java/com/zerobase/oriticket/OriticketApplication.java
+++ b/src/main/java/com/zerobase/oriticket/OriticketApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication //(exclude = DataSourceAutoConfiguration.class)
 public class OriticketApplication {
 

--- a/src/main/java/com/zerobase/oriticket/OriticketApplication.java
+++ b/src/main/java/com/zerobase/oriticket/OriticketApplication.java
@@ -2,7 +2,6 @@ package com.zerobase.oriticket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication //(exclude = DataSourceAutoConfiguration.class)
 public class OriticketApplication {

--- a/src/main/java/com/zerobase/oriticket/OriticketApplication.java
+++ b/src/main/java/com/zerobase/oriticket/OriticketApplication.java
@@ -2,8 +2,9 @@ package com.zerobase.oriticket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication //(exclude = DataSourceAutoConfiguration.class)
 public class OriticketApplication {
 

--- a/src/main/java/com/zerobase/oriticket/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/chat/controller/ChatRoomController.java
@@ -42,7 +42,7 @@ public class ChatRoomController {
                 .body(chatRoom.map(ChatRoomResponse::fromEntity));
     }
 
-    @GetMapping("/transaction")
+    @GetMapping("/transactions")
     public ResponseEntity<ChatRoomResponse> getByTransaction(
             @RequestParam("id") Long transactionId
     ){

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/post/repository/PostSearchRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/post/repository/PostSearchRepository.java
@@ -7,9 +7,5 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 
 public interface PostSearchRepository extends ElasticsearchRepository<PostSearchDocument, Long> {
 
-    Page<PostSearchDocument> findAll(Pageable pageable);
-
     Page<PostSearchDocument> findAllBySportsNameContainingOrStadiumNameContainingOrHomeTeamNameContainingOrAwayTeamNameContaining(String sportsName, String stadiumName, String homeTeamName, String awayTeamName, Pageable pageable);
-
-
 }

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/post/service/PostSearchService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/post/service/PostSearchService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,6 +14,9 @@ import org.springframework.stereotype.Service;
 public class PostSearchService {
 
     private final PostSearchRepository postSearchRepository;
+
+    private final static String CREATED_AT = "createdAt";
+    private final Sort sort = Sort.by(CREATED_AT).descending();
 
     public Page<PostSearchDocument> search(String value, int page, int size) {
 
@@ -25,14 +29,14 @@ public class PostSearchService {
 
     private Page<PostSearchDocument> searchAll(int page, int size){
 
-        Pageable pageable = PageRequest.of(page-1, size);
+        Pageable pageable = PageRequest.of(page-1, size, sort);
 
         return postSearchRepository.findAll(pageable);
     }
 
     private Page<PostSearchDocument> searchByCategoryName(String value, int page, int size){
 
-        Pageable pageable = PageRequest.of(page-1, size);
+        Pageable pageable = PageRequest.of(page-1, size, sort);
 
         return postSearchRepository.findAllBySportsNameContainingOrStadiumNameContainingOrHomeTeamNameContainingOrAwayTeamNameContaining
                 (value, value, value, value, pageable);

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/controller/ReportSearchController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/controller/ReportSearchController.java
@@ -1,0 +1,51 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.controller;
+
+import com.zerobase.oriticket.domain.elasticsearch.report.dto.ReportPostSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.report.dto.ReportTransactionSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportPostSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportTransactionSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.report.service.ReportPostSearchService;
+import com.zerobase.oriticket.domain.elasticsearch.report.service.ReportTransactionSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/report")
+public class ReportSearchController {
+
+    private final ReportPostSearchService reportPostSearchService;
+    private final ReportTransactionSearchService reportTransactionSearchService;
+
+    @GetMapping("/posts/search")
+    public ResponseEntity<Page<ReportPostSearchResponse>> searchReportPost(
+            @RequestParam(name = "name", required = false) String memberName,
+            @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ){
+        Page<ReportPostSearchDocument> reportPostSearchDocuments =
+                reportPostSearchService.search(memberName, page, size);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(reportPostSearchDocuments.map(reportPostSearchService::entityToDto));
+    }
+
+    @GetMapping("/transactions/search")
+    public ResponseEntity<Page<ReportTransactionSearchResponse>> searchReportTransaction(
+            @RequestParam(name = "name", required = false) String memberName,
+            @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ){
+        Page<ReportTransactionSearchDocument> reportTransactionSearchDocuments =
+                reportTransactionSearchService.search(memberName, page, size);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(reportTransactionSearchDocuments.map(reportTransactionSearchService::entityToDto));
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/dto/ReportPostSearchResponse.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/dto/ReportPostSearchResponse.java
@@ -1,0 +1,40 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.dto;
+
+import com.zerobase.oriticket.domain.elasticsearch.post.dto.PostSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.post.entity.PostSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportPostSearchDocument;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class ReportPostSearchResponse {
+
+    private Long reportPostId;
+    private String memberName;
+    private PostSearchResponse salePost;
+    private String reason;
+    private LocalDateTime reportedAt;
+    private ReportReactStatus status;
+    private LocalDateTime reactedAt;
+    private String note;
+
+    public static ReportPostSearchResponse fromEntity(
+            ReportPostSearchDocument reportPostSearchDocument,
+            PostSearchDocument postSearchDocument
+    ){
+        return ReportPostSearchResponse.builder()
+                .reportPostId(reportPostSearchDocument.getReportPostId())
+                .memberName(reportPostSearchDocument.getMemberName())
+                .salePost(PostSearchResponse.fromEntity(postSearchDocument))
+                .reason(reportPostSearchDocument.getReason())
+                .reportedAt(reportPostSearchDocument.getReportedAt())
+                .status(reportPostSearchDocument.getStatus())
+                .reactedAt(reportPostSearchDocument.getReactedAt())
+                .note(reportPostSearchDocument.getNote())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/dto/ReportTransactionSearchResponse.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/dto/ReportTransactionSearchResponse.java
@@ -1,0 +1,40 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.dto;
+
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportTransactionSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.transaction.dto.TransactionSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.transaction.entity.TransactionSearchDocument;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class ReportTransactionSearchResponse {
+
+    private Long reportTransactionId;
+    private String memberName;
+    private TransactionSearchResponse transaction;
+    private String reason;
+    private LocalDateTime reportedAt;
+    private ReportReactStatus status;
+    private LocalDateTime reactedAt;
+    private String note;
+
+    public static ReportTransactionSearchResponse fromEntity(
+            ReportTransactionSearchDocument reportPostSearchDocument,
+            TransactionSearchDocument transactionSearchDocument
+    ){
+        return ReportTransactionSearchResponse.builder()
+                .reportTransactionId(reportPostSearchDocument.getReportTransactionId())
+                .memberName(reportPostSearchDocument.getMemberName())
+                .transaction(TransactionSearchResponse.fromEntity(transactionSearchDocument))
+                .reason(reportPostSearchDocument.getReason())
+                .reportedAt(reportPostSearchDocument.getReportedAt())
+                .status(reportPostSearchDocument.getStatus())
+                .reactedAt(reportPostSearchDocument.getReactedAt())
+                .note(reportPostSearchDocument.getNote())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/entity/ReportPostSearchDocument.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/entity/ReportPostSearchDocument.java
@@ -1,0 +1,51 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.entity;
+
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.entity.ReportPost;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+
+@Document(indexName = "report-post")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class ReportPostSearchDocument {
+
+    @Id
+    private Long reportPostId;
+
+    private String memberName;
+    private Long salePostId;
+    private String reason;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
+    private LocalDateTime reportedAt;
+
+    private ReportReactStatus status;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
+    private LocalDateTime reactedAt;
+    private String note;
+
+    public static ReportPostSearchDocument fromEntity(ReportPost reportPost) {
+        return ReportPostSearchDocument.builder()
+                .reportPostId(reportPost.getReportPostId())
+                .memberName("reported member")
+//                .memberName(reportPost.getMember().getUserName())
+                .salePostId(reportPost.getSalePost().getSalePostId())
+                .reason(reportPost.getReason().getReportType())
+                .reportedAt(reportPost.getReportedAt())
+                .status(reportPost.getStatus())
+                .reactedAt(reportPost.getReactedAt())
+                .note(reportPost.getNote())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/entity/ReportTransactionSearchDocument.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/entity/ReportTransactionSearchDocument.java
@@ -1,0 +1,51 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.entity;
+
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+
+@Document(indexName = "report-transaction")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class ReportTransactionSearchDocument {
+
+    @Id
+    private Long reportTransactionId;
+
+    private String memberName;
+    private Long transactionId;
+    private String reason;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
+    private LocalDateTime reportedAt;
+
+    private ReportReactStatus status;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
+    private LocalDateTime reactedAt;
+    private String note;
+
+    public static ReportTransactionSearchDocument fromEntity(ReportTransaction reportTransaction){
+        return ReportTransactionSearchDocument.builder()
+                .reportTransactionId(reportTransaction.getReportTransactionId())
+                .memberName("reported member")
+//                .memberName(reportTransaction.getMemberId().getUserName())
+                .transactionId(reportTransaction.getTransaction().getTransactionId())
+                .reason(reportTransaction.getReason().getReportType())
+                .reportedAt(reportTransaction.getReportedAt())
+                .status(reportTransaction.getStatus())
+                .reactedAt(reportTransaction.getReactedAt())
+                .note(reportTransaction.getNote())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/repository/ReportPostSearchRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/repository/ReportPostSearchRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.repository;
+
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportPostSearchDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ReportPostSearchRepository
+        extends ElasticsearchRepository<ReportPostSearchDocument, Long> {
+
+    Page<ReportPostSearchDocument> findAllByMemberNameContaining(String memberName, Pageable pageable);
+}

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/repository/ReportTransactionSearchRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/repository/ReportTransactionSearchRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.repository;
+
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportTransactionSearchDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ReportTransactionSearchRepository
+        extends ElasticsearchRepository<ReportTransactionSearchDocument, Long> {
+    Page<ReportTransactionSearchDocument> findAllByMemberNameContaining(String memberName, Pageable pageable);
+}

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/service/ReportPostSearchService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/service/ReportPostSearchService.java
@@ -1,0 +1,59 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.service;
+
+import com.zerobase.oriticket.domain.elasticsearch.post.entity.PostSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.post.repository.PostSearchRepository;
+import com.zerobase.oriticket.domain.elasticsearch.report.dto.ReportPostSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportPostSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.report.repository.ReportPostSearchRepository;
+import com.zerobase.oriticket.global.constants.PostExceptionStatus;
+import com.zerobase.oriticket.global.exception.impl.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportPostSearchService {
+
+    private final ReportPostSearchRepository reportPostSearchRepository;
+    private final PostSearchRepository postSearchRepository;
+
+    private final static String REPORTED_AT = "reportedAt";
+    private final Sort sort = Sort.by(REPORTED_AT).descending();
+
+    public Page<ReportPostSearchDocument> search(String memberName, int page, int size) {
+
+        if(memberName == null){
+            return searchAll(page, size);
+        }
+
+        return searchByMemberName(memberName, page, size);
+    }
+
+    public ReportPostSearchResponse entityToDto(ReportPostSearchDocument reportPostSearchDocument){
+
+        PostSearchDocument postSearchDocument =
+                postSearchRepository.findById(reportPostSearchDocument.getSalePostId())
+                .orElseThrow(() -> new CustomException(PostExceptionStatus.SALE_POST_NOT_FOUND.getCode(),
+                        PostExceptionStatus.SALE_POST_NOT_FOUND.getMessage()));
+
+        return ReportPostSearchResponse.fromEntity(reportPostSearchDocument, postSearchDocument);
+    }
+
+    private Page<ReportPostSearchDocument> searchAll(int page, int size){
+
+        Pageable pageable = PageRequest.of(page-1, size, sort);
+
+        return reportPostSearchRepository.findAll(pageable);
+    }
+
+    private Page<ReportPostSearchDocument> searchByMemberName(String memberName, int page, int size) {
+
+        Pageable pageable = PageRequest.of(page-1, size, sort);
+
+        return reportPostSearchRepository.findAllByMemberNameContaining(memberName, pageable);
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/service/ReportTransactionSearchService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/report/service/ReportTransactionSearchService.java
@@ -1,0 +1,59 @@
+package com.zerobase.oriticket.domain.elasticsearch.report.service;
+
+import com.zerobase.oriticket.domain.elasticsearch.report.dto.ReportTransactionSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportTransactionSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.report.repository.ReportTransactionSearchRepository;
+import com.zerobase.oriticket.domain.elasticsearch.transaction.entity.TransactionSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.transaction.repository.TransactionSearchRepository;
+import com.zerobase.oriticket.global.constants.TransactionExceptionStatus;
+import com.zerobase.oriticket.global.exception.impl.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportTransactionSearchService {
+
+    private final ReportTransactionSearchRepository reportTransactionSearchRepository;
+    private final TransactionSearchRepository transactionSearchRepository;
+
+    private final static String REPORTED_AT = "reportedAt";
+    private final Sort sort = Sort.by(REPORTED_AT).descending();
+
+    public Page<ReportTransactionSearchDocument> search(String memberName, int page, int size) {
+
+        if(memberName == null){
+            return searchAll(page, size);
+        }
+
+        return searchByMemberName(memberName, page, size);
+    }
+
+    public ReportTransactionSearchResponse entityToDto(ReportTransactionSearchDocument reportTransactionSearchDocument){
+
+        TransactionSearchDocument transactionSearchDocument =
+                transactionSearchRepository.findById(reportTransactionSearchDocument.getTransactionId())
+                .orElseThrow(() -> new CustomException(TransactionExceptionStatus.TRANSACTION_NOT_FOUND.getCode(),
+                        TransactionExceptionStatus.TRANSACTION_NOT_FOUND.getMessage()));
+
+        return ReportTransactionSearchResponse.fromEntity(reportTransactionSearchDocument, transactionSearchDocument);
+    }
+
+    private Page<ReportTransactionSearchDocument> searchAll(int page, int size){
+
+        Pageable pageable = PageRequest.of(page-1, size, sort);
+
+        return reportTransactionSearchRepository.findAll(pageable);
+    }
+
+    private Page<ReportTransactionSearchDocument> searchByMemberName(String memberName, int page, int size) {
+
+        Pageable pageable = PageRequest.of(page-1, size, sort);
+
+        return reportTransactionSearchRepository.findAllByMemberNameContaining(memberName, pageable);
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/constants/ReportPostType.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/constants/ReportPostType.java
@@ -1,0 +1,16 @@
+package com.zerobase.oriticket.domain.report.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportPostType {
+
+    OVERPRICED_REGISTRATION("Overpriced registration"),
+    SUSPECTED_FALSE_INFORMATION("Suspected false information"),
+    INAPPROPRIATE_PHOTO("Inappropriate photo"),
+    OTHER_ISSUES("Other issues");
+
+    private String reportType;
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/constants/ReportReactStatus.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/constants/ReportReactStatus.java
@@ -1,0 +1,6 @@
+package com.zerobase.oriticket.domain.report.constants;
+
+public enum ReportReactStatus {
+    PROCESSING,
+    REACTED
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/constants/ReportTransactionType.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/constants/ReportTransactionType.java
@@ -1,0 +1,13 @@
+package com.zerobase.oriticket.domain.report.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportTransactionType {
+    ECONOMIC_LOSS("Economic loss"),
+    MATERIAL_LOSS("Material loss");
+
+    private String reportType;
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/controller/ReportPostController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/controller/ReportPostController.java
@@ -1,0 +1,41 @@
+package com.zerobase.oriticket.domain.report.controller;
+
+import com.zerobase.oriticket.domain.report.dto.RegisterReportPostRequest;
+import com.zerobase.oriticket.domain.report.dto.ReportPostResponse;
+import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
+import com.zerobase.oriticket.domain.report.entity.ReportPost;
+import com.zerobase.oriticket.domain.report.service.ReportPostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class ReportPostController {
+
+    private final ReportPostService reportPostService;
+
+    @PostMapping("/{salePostId}/report")
+    public ResponseEntity<ReportPostResponse> register(
+            @PathVariable("salePostId") Long salePostId,
+            @RequestBody RegisterReportPostRequest request
+    ){
+        ReportPost reportPost = reportPostService.register(salePostId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ReportPostResponse.fromEntity(reportPost));
+    }
+
+    @PatchMapping("/report/{reportPostId}")
+    public ResponseEntity<ReportPostResponse> updateToReacted(
+            @PathVariable("reportPostId") Long reportPostId,
+            @RequestBody UpdateReportRequest request
+            ){
+        ReportPost reportPost = reportPostService.updateToReacted(reportPostId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ReportPostResponse.fromEntity(reportPost));
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/controller/ReportTransactionController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/controller/ReportTransactionController.java
@@ -1,0 +1,41 @@
+package com.zerobase.oriticket.domain.report.controller;
+
+import com.zerobase.oriticket.domain.report.dto.RegisterReportTransactionRequest;
+import com.zerobase.oriticket.domain.report.dto.ReportTransactionResponse;
+import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
+import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
+import com.zerobase.oriticket.domain.report.service.ReportTransactionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/transactions")
+public class ReportTransactionController {
+
+    private final ReportTransactionService reportTransactionService;
+
+    @PostMapping("/{transactionId}/report")
+    public ResponseEntity<ReportTransactionResponse> register(
+            @PathVariable("transactionId") Long transactionId,
+            @RequestBody RegisterReportTransactionRequest request
+    ){
+        ReportTransaction reportTransaction = reportTransactionService.register(transactionId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ReportTransactionResponse.fromEntity(reportTransaction));
+    }
+
+    @PatchMapping("/report/{reportTransactionId}")
+    public ResponseEntity<ReportTransactionResponse> updateToReacted(
+            @PathVariable("reportTransactionId") Long reportTransactionId,
+            @RequestBody UpdateReportRequest request
+            ){
+        ReportTransaction reportTransaction = reportTransactionService.updateToReacted(reportTransactionId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ReportTransactionResponse.fromEntity(reportTransaction));
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/dto/RegisterReportPostRequest.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/dto/RegisterReportPostRequest.java
@@ -1,0 +1,32 @@
+package com.zerobase.oriticket.domain.report.dto;
+
+import com.zerobase.oriticket.domain.post.entity.Post;
+import com.zerobase.oriticket.domain.report.constants.ReportPostType;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.entity.ReportPost;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterReportPostRequest {
+
+    private Long memberId;
+    private String reason;
+
+    public ReportPost toEntity(Post salePost){
+
+        ReportPostType reportType = ReportPostType.valueOf(reason.toUpperCase());
+
+        return ReportPost.builder()
+                .memberId(this.memberId)
+                .salePost(salePost)
+                .reason(reportType)
+                .status(ReportReactStatus.PROCESSING)
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/dto/RegisterReportTransactionRequest.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/dto/RegisterReportTransactionRequest.java
@@ -1,0 +1,32 @@
+package com.zerobase.oriticket.domain.report.dto;
+
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.constants.ReportTransactionType;
+import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
+import com.zerobase.oriticket.domain.transaction.entity.Transaction;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterReportTransactionRequest {
+
+    private Long memberId;
+    private String reason;
+
+    public ReportTransaction toEntity(Transaction transaction){
+
+        ReportTransactionType reportType = ReportTransactionType.valueOf(reason.toUpperCase());
+
+        return ReportTransaction.builder()
+                .memberId(this.memberId)
+                .transaction(transaction)
+                .reason(reportType)
+                .status(ReportReactStatus.PROCESSING)
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/dto/ReportPostResponse.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/dto/ReportPostResponse.java
@@ -1,0 +1,37 @@
+package com.zerobase.oriticket.domain.report.dto;
+
+import com.zerobase.oriticket.domain.post.dto.PostResponse;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.entity.ReportPost;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReportPostResponse {
+
+    private Long reportPostId;
+    private Long memberId;
+    private PostResponse salePost;
+    private String reason;
+    private LocalDateTime reportedAt;
+    private ReportReactStatus status;
+    private LocalDateTime reactedAt;
+    private String note;
+
+    public static ReportPostResponse fromEntity(ReportPost reportPost){
+
+        return ReportPostResponse.builder()
+                .reportPostId(reportPost.getReportPostId())
+                .memberId(reportPost.getMemberId())
+                .salePost(PostResponse.fromEntity(reportPost.getSalePost()))
+                .reason(reportPost.getReason().getReportType())
+                .reportedAt(reportPost.getReportedAt())
+                .status(reportPost.getStatus())
+                .reactedAt(reportPost.getReactedAt())
+                .note(reportPost.getNote())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/dto/ReportTransactionResponse.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/dto/ReportTransactionResponse.java
@@ -1,0 +1,37 @@
+package com.zerobase.oriticket.domain.report.dto;
+
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
+import com.zerobase.oriticket.domain.transaction.dto.TransactionResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReportTransactionResponse {
+
+    private Long reportTradeId;
+    private Long memberId;
+    private TransactionResponse transaction;
+    private String reason;
+    private LocalDateTime reportedAt;
+    private ReportReactStatus status;
+    private LocalDateTime reactedAt;
+    private String note;
+
+    public static ReportTransactionResponse fromEntity(ReportTransaction reportTransaction){
+
+        return ReportTransactionResponse.builder()
+                .reportTradeId(reportTransaction.getReportTradeId())
+                .memberId(reportTransaction.getReportTradeId())
+                .transaction(TransactionResponse.fromEntity(reportTransaction.getTransaction()))
+                .reason(reportTransaction.getReason().getReportType())
+                .reportedAt(reportTransaction.getReportedAt())
+                .status(reportTransaction.getStatus())
+                .reactedAt(reportTransaction.getReactedAt())
+                .note(reportTransaction.getNote())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/dto/ReportTransactionResponse.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/dto/ReportTransactionResponse.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ReportTransactionResponse {
 
-    private Long reportTradeId;
+    private Long reportTransactionId;
     private Long memberId;
     private TransactionResponse transaction;
     private String reason;
@@ -24,8 +24,8 @@ public class ReportTransactionResponse {
     public static ReportTransactionResponse fromEntity(ReportTransaction reportTransaction){
 
         return ReportTransactionResponse.builder()
-                .reportTradeId(reportTransaction.getReportTradeId())
-                .memberId(reportTransaction.getReportTradeId())
+                .reportTransactionId(reportTransaction.getReportTransactionId())
+                .memberId(reportTransaction.getMemberId())
                 .transaction(TransactionResponse.fromEntity(reportTransaction.getTransaction()))
                 .reason(reportTransaction.getReason().getReportType())
                 .reportedAt(reportTransaction.getReportedAt())

--- a/src/main/java/com/zerobase/oriticket/domain/report/dto/UpdateReportRequest.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/dto/UpdateReportRequest.java
@@ -1,0 +1,14 @@
+package com.zerobase.oriticket.domain.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateReportRequest {
+    private String note;
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/entity/ReportPost.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/entity/ReportPost.java
@@ -1,0 +1,43 @@
+package com.zerobase.oriticket.domain.report.entity;
+
+import com.zerobase.oriticket.domain.post.entity.Post;
+import com.zerobase.oriticket.domain.report.constants.ReportPostType;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class ReportPost {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportPostId;
+
+//    @ManyToOne
+    private Long memberId;
+
+    @ManyToOne
+    private Post salePost;
+
+    private ReportPostType reason;
+
+    @CreatedDate
+    private LocalDateTime reportedAt;
+
+    private ReportReactStatus status;
+
+    private LocalDateTime reactedAt;
+
+    private String note;
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/entity/ReportTransaction.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/entity/ReportTransaction.java
@@ -22,7 +22,7 @@ public class ReportTransaction {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long reportTradeId;
+    private Long reportTransactionId;
 
 //    @ManyToOne
     private Long memberId;

--- a/src/main/java/com/zerobase/oriticket/domain/report/entity/ReportTransaction.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/entity/ReportTransaction.java
@@ -1,0 +1,43 @@
+package com.zerobase.oriticket.domain.report.entity;
+
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.constants.ReportTransactionType;
+import com.zerobase.oriticket.domain.transaction.entity.Transaction;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class ReportTransaction {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportTradeId;
+
+//    @ManyToOne
+    private Long memberId;
+
+    @ManyToOne
+    private Transaction transaction;
+
+    private ReportTransactionType reason;
+
+    @CreatedDate
+    private LocalDateTime reportedAt;
+
+    private ReportReactStatus status;
+
+    private LocalDateTime reactedAt;
+
+    private String note;
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportPostRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportPostRepository.java
@@ -1,9 +1,11 @@
 package com.zerobase.oriticket.domain.report.repository;
 
+import com.zerobase.oriticket.domain.report.constants.ReportPostType;
 import com.zerobase.oriticket.domain.report.entity.ReportPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReportPostRepository extends JpaRepository<ReportPost, Long> {
+    boolean existsBySalePostIdAndMemberIdAndReason(Long salePostId, Long memberId, ReportPostType reason);
 }

--- a/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportPostRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportPostRepository.java
@@ -1,0 +1,9 @@
+package com.zerobase.oriticket.domain.report.repository;
+
+import com.zerobase.oriticket.domain.report.entity.ReportPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportPostRepository extends JpaRepository<ReportPost, Long> {
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportPostRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportPostRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReportPostRepository extends JpaRepository<ReportPost, Long> {
-    boolean existsBySalePostIdAndMemberIdAndReason(Long salePostId, Long memberId, ReportPostType reason);
+    boolean existsBySalePost_SalePostIdAndMemberIdAndReason(Long salePostId, Long memberId, ReportPostType reason);
 }

--- a/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportTransactionRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportTransactionRepository.java
@@ -5,5 +5,5 @@ import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportTransactionRepository extends JpaRepository<ReportTransaction, Long> {
-    boolean existsBySalePostIdAndMemberIdAndReason(Long transactionId, Long memberId, ReportTransactionType reason);
+    boolean existsByTransaction_TransactionIdAndMemberIdAndReason(Long transactionId, Long memberId, ReportTransactionType reason);
 }

--- a/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportTransactionRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportTransactionRepository.java
@@ -1,7 +1,9 @@
 package com.zerobase.oriticket.domain.report.repository;
 
+import com.zerobase.oriticket.domain.report.constants.ReportTransactionType;
 import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportTransactionRepository extends JpaRepository<ReportTransaction, Long> {
+    boolean existsBySalePostIdAndMemberIdAndReason(Long transactionId, Long memberId, ReportTransactionType reason);
 }

--- a/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportTransactionRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/repository/ReportTransactionRepository.java
@@ -1,0 +1,7 @@
+package com.zerobase.oriticket.domain.report.repository;
+
+import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportTransactionRepository extends JpaRepository<ReportTransaction, Long> {
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/service/ReportPostService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/service/ReportPostService.java
@@ -1,5 +1,7 @@
 package com.zerobase.oriticket.domain.report.service;
 
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportPostSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.report.repository.ReportPostSearchRepository;
 import com.zerobase.oriticket.domain.post.entity.Post;
 import com.zerobase.oriticket.domain.post.repository.PostRepository;
 import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
@@ -20,6 +22,7 @@ import java.time.LocalDateTime;
 public class ReportPostService {
 
     private final ReportPostRepository reportPostRepository;
+    private final ReportPostSearchRepository reportPostSearchRepository;
     private final PostRepository postRepository;
 
     public ReportPost register(Long salePostId, RegisterReportPostRequest request) {
@@ -27,7 +30,10 @@ public class ReportPostService {
                 .orElseThrow(() -> new CustomException(PostExceptionStatus.SALE_POST_NOT_FOUND.getCode(),
                         PostExceptionStatus.SALE_POST_NOT_FOUND.getMessage()));
 
-        return reportPostRepository.save(request.toEntity(salePost));
+        ReportPost reportPost = reportPostRepository.save(request.toEntity(salePost));
+        reportPostSearchRepository.save(ReportPostSearchDocument.fromEntity(reportPost));
+
+        return reportPost;
     }
 
     public ReportPost updateToReacted(Long reportPostId, UpdateReportRequest request) {
@@ -38,6 +44,7 @@ public class ReportPostService {
         reportPost.setStatus(ReportReactStatus.REACTED);
         reportPost.setReactedAt(LocalDateTime.now());
         reportPost.setNote(request.getNote());
+        reportPostSearchRepository.save(ReportPostSearchDocument.fromEntity(reportPost));
 
         return reportPostRepository.save(reportPost);
     }

--- a/src/main/java/com/zerobase/oriticket/domain/report/service/ReportPostService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/service/ReportPostService.java
@@ -1,0 +1,44 @@
+package com.zerobase.oriticket.domain.report.service;
+
+import com.zerobase.oriticket.domain.post.entity.Post;
+import com.zerobase.oriticket.domain.post.repository.PostRepository;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.dto.RegisterReportPostRequest;
+import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
+import com.zerobase.oriticket.domain.report.entity.ReportPost;
+import com.zerobase.oriticket.domain.report.repository.ReportPostRepository;
+import com.zerobase.oriticket.global.constants.PostExceptionStatus;
+import com.zerobase.oriticket.global.constants.ReportExceptionStatus;
+import com.zerobase.oriticket.global.exception.impl.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReportPostService {
+
+    private final ReportPostRepository reportPostRepository;
+    private final PostRepository postRepository;
+
+    public ReportPost register(Long salePostId, RegisterReportPostRequest request) {
+        Post salePost = postRepository.findById(salePostId)
+                .orElseThrow(() -> new CustomException(PostExceptionStatus.SALE_POST_NOT_FOUND.getCode(),
+                        PostExceptionStatus.SALE_POST_NOT_FOUND.getMessage()));
+
+        return reportPostRepository.save(request.toEntity(salePost));
+    }
+
+    public ReportPost updateToReacted(Long reportPostId, UpdateReportRequest request) {
+        ReportPost reportPost = reportPostRepository.findById(reportPostId)
+                .orElseThrow(() -> new CustomException(ReportExceptionStatus.REPORT_POST_NOT_FOUND.getCode(),
+                        ReportExceptionStatus.REPORT_POST_NOT_FOUND.getMessage()));
+
+        reportPost.setStatus(ReportReactStatus.REACTED);
+        reportPost.setReactedAt(LocalDateTime.now());
+        reportPost.setNote(request.getNote());
+
+        return reportPostRepository.save(reportPost);
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/service/ReportPostService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/service/ReportPostService.java
@@ -4,6 +4,7 @@ import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportPostSearc
 import com.zerobase.oriticket.domain.elasticsearch.report.repository.ReportPostSearchRepository;
 import com.zerobase.oriticket.domain.post.entity.Post;
 import com.zerobase.oriticket.domain.post.repository.PostRepository;
+import com.zerobase.oriticket.domain.report.constants.ReportPostType;
 import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
 import com.zerobase.oriticket.domain.report.dto.RegisterReportPostRequest;
 import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
@@ -14,6 +15,7 @@ import com.zerobase.oriticket.global.constants.ReportExceptionStatus;
 import com.zerobase.oriticket.global.exception.impl.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -25,10 +27,13 @@ public class ReportPostService {
     private final ReportPostSearchRepository reportPostSearchRepository;
     private final PostRepository postRepository;
 
+    @Transactional
     public ReportPost register(Long salePostId, RegisterReportPostRequest request) {
         Post salePost = postRepository.findById(salePostId)
                 .orElseThrow(() -> new CustomException(PostExceptionStatus.SALE_POST_NOT_FOUND.getCode(),
                         PostExceptionStatus.SALE_POST_NOT_FOUND.getMessage()));
+
+        validateCanRegister(salePostId, request);
 
         ReportPost reportPost = reportPostRepository.save(request.toEntity(salePost));
         reportPostSearchRepository.save(ReportPostSearchDocument.fromEntity(reportPost));
@@ -36,6 +41,7 @@ public class ReportPostService {
         return reportPost;
     }
 
+    @Transactional
     public ReportPost updateToReacted(Long reportPostId, UpdateReportRequest request) {
         ReportPost reportPost = reportPostRepository.findById(reportPostId)
                 .orElseThrow(() -> new CustomException(ReportExceptionStatus.REPORT_POST_NOT_FOUND.getCode(),
@@ -47,5 +53,14 @@ public class ReportPostService {
         reportPostSearchRepository.save(ReportPostSearchDocument.fromEntity(reportPost));
 
         return reportPostRepository.save(reportPost);
+    }
+
+    private void validateCanRegister(Long salePostId, RegisterReportPostRequest request){
+        if(reportPostRepository.existsBySalePostIdAndMemberIdAndReason(
+                salePostId, request.getMemberId(), ReportPostType.valueOf(request.getReason().toUpperCase()))
+        ){
+            throw new CustomException(ReportExceptionStatus.CANNOT_REGISTER_REPORT_POST.getCode(),
+                    ReportExceptionStatus.CANNOT_REGISTER_REPORT_POST.getMessage());
+        }
     }
 }

--- a/src/main/java/com/zerobase/oriticket/domain/report/service/ReportPostService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/service/ReportPostService.java
@@ -56,7 +56,7 @@ public class ReportPostService {
     }
 
     private void validateCanRegister(Long salePostId, RegisterReportPostRequest request){
-        if(reportPostRepository.existsBySalePostIdAndMemberIdAndReason(
+        if(reportPostRepository.existsBySalePost_SalePostIdAndMemberIdAndReason(
                 salePostId, request.getMemberId(), ReportPostType.valueOf(request.getReason().toUpperCase()))
         ){
             throw new CustomException(ReportExceptionStatus.CANNOT_REGISTER_REPORT_POST.getCode(),

--- a/src/main/java/com/zerobase/oriticket/domain/report/service/ReportTransactionService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/service/ReportTransactionService.java
@@ -1,0 +1,44 @@
+package com.zerobase.oriticket.domain.report.service;
+
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.dto.RegisterReportTransactionRequest;
+import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
+import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
+import com.zerobase.oriticket.domain.report.repository.ReportTransactionRepository;
+import com.zerobase.oriticket.domain.transaction.entity.Transaction;
+import com.zerobase.oriticket.domain.transaction.repository.TransactionRepository;
+import com.zerobase.oriticket.global.constants.ReportExceptionStatus;
+import com.zerobase.oriticket.global.constants.TransactionExceptionStatus;
+import com.zerobase.oriticket.global.exception.impl.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReportTransactionService {
+
+    private final ReportTransactionRepository reportTransactionRepository;
+    private final TransactionRepository transactionRepository;
+
+    public ReportTransaction register(Long transactionId, RegisterReportTransactionRequest request) {
+        Transaction transaction = transactionRepository.findById(transactionId)
+                .orElseThrow(() -> new CustomException(TransactionExceptionStatus.TRANSACTION_NOT_FOUND.getCode(),
+                        TransactionExceptionStatus.TRANSACTION_NOT_FOUND.getMessage()));
+
+        return reportTransactionRepository.save(request.toEntity(transaction));
+    }
+
+    public ReportTransaction updateToReacted(Long reportTransactionId, UpdateReportRequest request) {
+        ReportTransaction reportTransaction = reportTransactionRepository.findById(reportTransactionId)
+                .orElseThrow(() -> new CustomException(ReportExceptionStatus.REPORT_TRANSACTION_NOT_FOUND.getCode(),
+                        ReportExceptionStatus.REPORT_TRANSACTION_NOT_FOUND.getMessage()));
+
+        reportTransaction.setStatus(ReportReactStatus.REACTED);
+        reportTransaction.setReactedAt(LocalDateTime.now());
+        reportTransaction.setNote(request.getNote());
+
+        return reportTransactionRepository.save(reportTransaction);
+    }
+}

--- a/src/main/java/com/zerobase/oriticket/domain/report/service/ReportTransactionService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/service/ReportTransactionService.java
@@ -56,7 +56,7 @@ public class ReportTransactionService {
     }
 
     private void validateCanRegister(Long transactionId, RegisterReportTransactionRequest request){
-        if(reportTransactionRepository.existsBySalePostIdAndMemberIdAndReason(
+        if(reportTransactionRepository.existsByTransaction_TransactionIdAndMemberIdAndReason(
                 transactionId, request.getMemberId(), ReportTransactionType.valueOf(request.getReason().toUpperCase()))
         ){
             throw new CustomException(ReportExceptionStatus.CANNOT_REGISTER_REPORT_TRANSACTION.getCode(),

--- a/src/main/java/com/zerobase/oriticket/domain/report/service/ReportTransactionService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/report/service/ReportTransactionService.java
@@ -3,6 +3,7 @@ package com.zerobase.oriticket.domain.report.service;
 import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportTransactionSearchDocument;
 import com.zerobase.oriticket.domain.elasticsearch.report.repository.ReportTransactionSearchRepository;
 import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.constants.ReportTransactionType;
 import com.zerobase.oriticket.domain.report.dto.RegisterReportTransactionRequest;
 import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
 import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
@@ -14,6 +15,7 @@ import com.zerobase.oriticket.global.constants.TransactionExceptionStatus;
 import com.zerobase.oriticket.global.exception.impl.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -25,10 +27,13 @@ public class ReportTransactionService {
     private final TransactionRepository transactionRepository;
     private final ReportTransactionSearchRepository reportTransactionSearchRepository;
 
+    @Transactional
     public ReportTransaction register(Long transactionId, RegisterReportTransactionRequest request) {
         Transaction transaction = transactionRepository.findById(transactionId)
                 .orElseThrow(() -> new CustomException(TransactionExceptionStatus.TRANSACTION_NOT_FOUND.getCode(),
                         TransactionExceptionStatus.TRANSACTION_NOT_FOUND.getMessage()));
+
+        validateCanRegister(transactionId, request);
 
         ReportTransaction reportTransaction = reportTransactionRepository.save(request.toEntity(transaction));
         reportTransactionSearchRepository.save(ReportTransactionSearchDocument.fromEntity(reportTransaction));
@@ -36,6 +41,7 @@ public class ReportTransactionService {
         return reportTransaction;
     }
 
+    @Transactional
     public ReportTransaction updateToReacted(Long reportTransactionId, UpdateReportRequest request) {
         ReportTransaction reportTransaction = reportTransactionRepository.findById(reportTransactionId)
                 .orElseThrow(() -> new CustomException(ReportExceptionStatus.REPORT_TRANSACTION_NOT_FOUND.getCode(),
@@ -47,5 +53,14 @@ public class ReportTransactionService {
         reportTransactionSearchRepository.save(ReportTransactionSearchDocument.fromEntity(reportTransaction));
 
         return reportTransactionRepository.save(reportTransaction);
+    }
+
+    private void validateCanRegister(Long transactionId, RegisterReportTransactionRequest request){
+        if(reportTransactionRepository.existsBySalePostIdAndMemberIdAndReason(
+                transactionId, request.getMemberId(), ReportTransactionType.valueOf(request.getReason().toUpperCase()))
+        ){
+            throw new CustomException(ReportExceptionStatus.CANNOT_REGISTER_REPORT_TRANSACTION.getCode(),
+                    ReportExceptionStatus.CANNOT_REGISTER_REPORT_TRANSACTION.getMessage());
+        }
     }
 }

--- a/src/main/java/com/zerobase/oriticket/domain/transaction/constants/TransactionStatus.java
+++ b/src/main/java/com/zerobase/oriticket/domain/transaction/constants/TransactionStatus.java
@@ -13,5 +13,5 @@ public enum TransactionStatus {
     CANCELED("Canceled"),
     REPORTED("Reported");
 
-    private String state;
+    private final String state;
 }

--- a/src/main/java/com/zerobase/oriticket/domain/transaction/controller/TransactionFetchController.java
+++ b/src/main/java/com/zerobase/oriticket/domain/transaction/controller/TransactionFetchController.java
@@ -20,7 +20,7 @@ public class TransactionFetchController {
 
     private final TransactionFetchService transactionFetchService;
 
-    @GetMapping("/members/{memberId}/transaction")
+    @GetMapping("/members/{memberId}/transactions")
     public ResponseEntity<List<TransactionResponse>> get(
             @PathVariable("memberId") Long memberId,
             @RequestParam("status") List<String> statusList

--- a/src/main/java/com/zerobase/oriticket/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/zerobase/oriticket/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.zerobase.oriticket.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/zerobase/oriticket/global/constants/ReportExceptionStatus.java
+++ b/src/main/java/com/zerobase/oriticket/global/constants/ReportExceptionStatus.java
@@ -1,0 +1,16 @@
+package com.zerobase.oriticket.global.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReportExceptionStatus {
+
+    REPORT_POST_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "판매 글 정보를 찾을 수 없습니다."),
+    REPORT_TRANSACTION_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "판매 글 정보를 찾을 수 없습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/zerobase/oriticket/global/constants/ReportExceptionStatus.java
+++ b/src/main/java/com/zerobase/oriticket/global/constants/ReportExceptionStatus.java
@@ -8,8 +8,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ReportExceptionStatus {
 
-    REPORT_POST_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "판매 글 정보를 찾을 수 없습니다."),
-    REPORT_TRANSACTION_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "판매 글 정보를 찾을 수 없습니다.");
+    REPORT_POST_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "판매 글 신고 정보를 찾을 수 없습니다."),
+    REPORT_TRANSACTION_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "거래 신고 정보를 찾을 수 없습니다."),
+    CANNOT_REGISTER_REPORT_POST(HttpStatus.BAD_REQUEST.value(), "판매 글 신고 정보 등록을 할 수 없습니다."),
+    CANNOT_REGISTER_REPORT_TRANSACTION(HttpStatus.BAD_REQUEST.value(), "거래 신고 정보 등록을 할 수 없습니다.");
+
 
     private final int code;
     private final String message;

--- a/src/main/java/com/zerobase/oriticket/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/zerobase/oriticket/global/exception/CustomExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -20,7 +21,7 @@ public class CustomExceptionHandler {
     }
 
     @ExceptionHandler(TypeMismatchException.class)
-    protected ResponseEntity<Void> handleRuntimeException(TypeMismatchException e) {
+    protected ResponseEntity<Void> handleTypeMismatchException(TypeMismatchException e) {
         log.error("TypeMismatchException..........");
         log.error(e.getMessage());
 
@@ -33,6 +34,14 @@ public class CustomExceptionHandler {
         log.error(e.getMessage());
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<Void> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("HttpRequestMethodNotSupportedException..........");
+        log.error(e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
     }
 
 }

--- a/src/test/java/com/zerobase/oriticket/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/chat/controller/ChatControllerTest.java
@@ -32,14 +32,14 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 public class ChatControllerTest {
 
-    @InjectMocks
-    private ChatController chatController;
-
     @Mock
     private ChatMessageService chatMessageService;
 
     @Mock
     private ContactChatMessageService contactChatMessageService;
+
+    @InjectMocks
+    private ChatController chatController;
 
     @Test
     @DisplayName("1:1 채팅 보내기 성공")

--- a/src/test/java/com/zerobase/oriticket/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/chat/controller/ChatRoomControllerTest.java
@@ -141,7 +141,7 @@ public class ChatRoomControllerTest {
 
         //when
         //then
-        mockMvc.perform(get(BASE_URL+"/transaction?id=1"))
+        mockMvc.perform(get(BASE_URL+"/transactions?id=1"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.chatRoomId").value(1L))

--- a/src/test/java/com/zerobase/oriticket/post/controller/StadiumControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/post/controller/StadiumControllerTest.java
@@ -117,8 +117,8 @@ public class StadiumControllerTest {
         //given
         Sports sports = createSports(SPORTS_ID, SPORTS_NAME);
         Stadium stadium1 = createStadium(1L, sports, "고척 돔", "한화");
-        Stadium stadium2 = createStadium(1L, sports, "잠실 야구장", "두산");
-        Stadium stadium3 = createStadium(1L, sports, "챔피언스 필드", "기아");
+        Stadium stadium2 = createStadium(2L, sports, "잠실 야구장", "두산");
+        Stadium stadium3 = createStadium(3L, sports, "챔피언스 필드", "기아");
         List<Stadium> stadiumList
                 = Arrays.asList(stadium1, stadium2, stadium3);
 

--- a/src/test/java/com/zerobase/oriticket/report/controller/ReportPostControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/report/controller/ReportPostControllerTest.java
@@ -1,0 +1,227 @@
+package com.zerobase.oriticket.report.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.entity.*;
+import com.zerobase.oriticket.domain.report.constants.ReportPostType;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.controller.ReportPostController;
+import com.zerobase.oriticket.domain.report.dto.RegisterReportPostRequest;
+import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
+import com.zerobase.oriticket.domain.report.entity.ReportPost;
+import com.zerobase.oriticket.domain.report.service.ReportPostService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportPostController.class)
+public class ReportPostControllerTest {
+
+    @MockBean
+    private ReportPostService reportPostService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final static String BASE_URL = "/posts";
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 20000;
+    private final static boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "seat info";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Long memberId, Ticket ticket, SaleStatus status){
+        return Post.builder()
+                .salePostId(salePostId)
+                .memberId(memberId)
+                .ticket(ticket)
+                .saleStatus(status)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private ReportPost createReportPost(
+            Long reportPostId,
+            Long memberId,
+            Post salePost,
+            ReportReactStatus status,
+            LocalDateTime reactedAt,
+            String note
+    ){
+        return ReportPost.builder()
+                .reportPostId(reportPostId)
+                .memberId(memberId)
+                .salePost(salePost)
+                .reason(ReportPostType.OTHER_ISSUES)
+                .reportedAt(LocalDateTime.now())
+                .status(status)
+                .reactedAt(reactedAt)
+                .note(note)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Report Post 등록 성공")
+    void successRegister() throws Exception {
+        //given
+        RegisterReportPostRequest registerRequest =
+                RegisterReportPostRequest.builder()
+                        .memberId(2L)
+                        .reason("Other_issues")
+                        .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "두산");
+        Ticket ticket = createTicket(10L, sports, stadium, awayTeam);
+        Post salePost = createPost(14L, 11L, ticket, SaleStatus.FOR_SALE);
+        ReportPost reportPost = createReportPost(5L, 2L, salePost,
+                ReportReactStatus.PROCESSING, null, null);
+
+        given(reportPostService.register(anyLong(), any(RegisterReportPostRequest.class)))
+                .willReturn(reportPost);
+
+        //when
+        //then
+        mockMvc.perform(post(BASE_URL+"/14/report")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registerRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reportPostId").value(5L))
+                .andExpect(jsonPath("$.memberId").value(2L))
+                .andExpect(jsonPath("$.salePost.salePostId").value(14L))
+                .andExpect(jsonPath("$.salePost.memberId").value(11L))
+                .andExpect(jsonPath("$.salePost.ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.salePost.ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.salePost.ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.salePost.ticket.awayTeamName").value("두산"))
+                .andExpect(jsonPath("$.salePost.ticket.quantity").value(1))
+                .andExpect(jsonPath("$.salePost.ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.salePost.ticket.originalPrice").value(20000))
+                .andExpect(jsonPath("$.salePost.ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.salePost.ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.salePost.ticket.seatInfo").value("seat info"))
+                .andExpect(jsonPath("$.salePost.ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.salePost.ticket.note").value("note"))
+                .andExpect(jsonPath("$.salePost.saleStatus").value("FOR_SALE"))
+                .andExpect(jsonPath("$.salePost.createdAt").exists())
+                .andExpect(jsonPath("$.reason").value(ReportPostType.OTHER_ISSUES.getReportType()))
+                .andExpect(jsonPath("$.reportedAt").exists())
+                .andExpect(jsonPath("$.status").value("PROCESSING"))
+                .andExpect(jsonPath("$.reactedAt").doesNotExist())
+                .andExpect(jsonPath("$.note").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("Report Post 처리 성공")
+    void successUpdateToReacted() throws Exception {
+        //given
+        UpdateReportRequest updateRequest =
+                UpdateReportRequest.builder()
+                        .note("react note")
+                        .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "두산");
+        Ticket ticket = createTicket(10L, sports, stadium, awayTeam);
+        Post salePost = createPost(14L, 11L, ticket, SaleStatus.FOR_SALE);
+        ReportPost reportPost = createReportPost(5L, 2L, salePost,
+                ReportReactStatus.REACTED, LocalDateTime.now(), "react note");
+
+        given(reportPostService.updateToReacted(anyLong(), any(UpdateReportRequest.class)))
+                .willReturn(reportPost);
+
+        //when
+        //then
+        mockMvc.perform(patch(BASE_URL+"/report/5")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reportPostId").value(5L))
+                .andExpect(jsonPath("$.memberId").value(2L))
+                .andExpect(jsonPath("$.salePost.salePostId").value(14L))
+                .andExpect(jsonPath("$.salePost.memberId").value(11L))
+                .andExpect(jsonPath("$.salePost.ticket.sportsName").value("야구"))
+                .andExpect(jsonPath("$.salePost.ticket.stadiumName").value("고척돔"))
+                .andExpect(jsonPath("$.salePost.ticket.homeTeamName").value("키움"))
+                .andExpect(jsonPath("$.salePost.ticket.awayTeamName").value("두산"))
+                .andExpect(jsonPath("$.salePost.ticket.quantity").value(1))
+                .andExpect(jsonPath("$.salePost.ticket.salePrice").value(10000))
+                .andExpect(jsonPath("$.salePost.ticket.originalPrice").value(20000))
+                .andExpect(jsonPath("$.salePost.ticket.expirationAt").exists())
+                .andExpect(jsonPath("$.salePost.ticket.isSuccessive").value(false))
+                .andExpect(jsonPath("$.salePost.ticket.seatInfo").value("seat info"))
+                .andExpect(jsonPath("$.salePost.ticket.imgUrl").value("image url"))
+                .andExpect(jsonPath("$.salePost.ticket.note").value("note"))
+                .andExpect(jsonPath("$.salePost.saleStatus").value("FOR_SALE"))
+                .andExpect(jsonPath("$.salePost.createdAt").exists())
+                .andExpect(jsonPath("$.reason").value(ReportPostType.OTHER_ISSUES.getReportType()))
+                .andExpect(jsonPath("$.reportedAt").exists())
+                .andExpect(jsonPath("$.status").value("REACTED"))
+                .andExpect(jsonPath("$.reactedAt").exists())
+                .andExpect(jsonPath("$.note").value("react note"));
+    }
+}

--- a/src/test/java/com/zerobase/oriticket/report/controller/ReportSearchControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/report/controller/ReportSearchControllerTest.java
@@ -1,0 +1,252 @@
+package com.zerobase.oriticket.report.controller;
+
+import com.zerobase.oriticket.domain.elasticsearch.post.dto.PostSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.report.controller.ReportSearchController;
+import com.zerobase.oriticket.domain.elasticsearch.report.dto.ReportPostSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.report.dto.ReportTransactionSearchResponse;
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportPostSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.report.entity.ReportTransactionSearchDocument;
+import com.zerobase.oriticket.domain.elasticsearch.report.service.ReportPostSearchService;
+import com.zerobase.oriticket.domain.elasticsearch.report.service.ReportTransactionSearchService;
+import com.zerobase.oriticket.domain.elasticsearch.transaction.dto.TransactionSearchResponse;
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.report.constants.ReportPostType;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.constants.ReportTransactionType;
+import com.zerobase.oriticket.domain.transaction.constants.TransactionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportSearchController.class)
+public class ReportSearchControllerTest {
+
+    @MockBean
+    private ReportPostSearchService reportPostSearchService;
+
+    @MockBean
+    private ReportTransactionSearchService reportTransactionSearchService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final static String BASE_URL = "/report";
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 20000;
+    private final static boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "seat info";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private PostSearchResponse createPostSearchResponse(
+            Long salePostId,
+            String memberName,
+            String sportsName,
+            String stadiumName,
+            String homeTeamName,
+            String awayTeamName
+    ){
+        return PostSearchResponse.builder()
+                .salePostId(salePostId)
+                .memberName(memberName)
+                .sportsName(sportsName)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .awayTeamName(awayTeamName)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(1))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .saleStatus(SaleStatus.FOR_SALE.toString())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private TransactionSearchResponse createTransactionSearchResponse(
+            Long transactionId,
+            Long salePostId,
+            String sellerName,
+            String buyerName,
+            Integer payAmount,
+            String status
+    ){
+        return TransactionSearchResponse.builder()
+                .transactionId(transactionId)
+                .salePostId(salePostId)
+                .sellerName(sellerName)
+                .buyerName(buyerName)
+                .payAmount(payAmount)
+                .status(status)
+                .receivedAt(LocalDateTime.now())
+                .startedAt(LocalDateTime.now())
+                .endedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private ReportPostSearchResponse createReportPostSearchResponse(
+            Long reportPostId,
+            String memberName,
+            PostSearchResponse salPost,
+            String note
+    ){
+        return ReportPostSearchResponse.builder()
+                .reportPostId(reportPostId)
+                .memberName(memberName)
+                .salePost(salPost)
+                .reason(ReportPostType.INAPPROPRIATE_PHOTO.getReportType())
+                .reportedAt(LocalDateTime.now())
+                .status(ReportReactStatus.REACTED)
+                .reactedAt(LocalDateTime.now())
+                .note(note)
+                .build();
+    }
+
+    private ReportTransactionSearchResponse createReportTransactionSearchResponse(
+            Long reportTransactionId,
+            String memberName,
+            TransactionSearchResponse transaction,
+            String note
+    ){
+        return ReportTransactionSearchResponse.builder()
+                .reportTransactionId(reportTransactionId)
+                .memberName(memberName)
+                .transaction(transaction)
+                .reason(ReportTransactionType.ECONOMIC_LOSS.getReportType())
+                .reportedAt(LocalDateTime.now())
+                .status(ReportReactStatus.REACTED)
+                .reactedAt(LocalDateTime.now())
+                .note(note)
+                .build();
+    }
+
+    private ReportPostSearchDocument createReportPostSearchDocument(
+            Long reportPostId,
+            String memberName,
+            Long salePostId,
+            String reason,
+            ReportReactStatus status
+    ){
+        return ReportPostSearchDocument.builder()
+                .reportPostId(reportPostId)
+                .memberName(memberName)
+                .salePostId(salePostId)
+                .reason(reason)
+                .reportedAt(LocalDateTime.now())
+                .status(status)
+                .build();
+    }
+
+    private ReportTransactionSearchDocument createReportTransactionSearchDocument(
+            Long reportTransactionId,
+            String memberName,
+            Long transactionId,
+            String reason,
+            ReportReactStatus status
+    ){
+        return ReportTransactionSearchDocument.builder()
+                .reportTransactionId(reportTransactionId)
+                .memberName(memberName)
+                .transactionId(transactionId)
+                .reason(reason)
+                .reportedAt(LocalDateTime.now())
+                .status(status)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Report Post 검색 성공")
+    void successReportPost() throws Exception {
+        //given
+        PostSearchResponse postSearchResponse =
+                createPostSearchResponse(10L, "seller name", "야구",
+                        "고척돔", "키움", "한화");
+        ReportPostSearchDocument reportPostSearchDocument =
+                createReportPostSearchDocument(1L, "first member", 10L,
+                        ReportPostType.OTHER_ISSUES.getReportType(), ReportReactStatus.PROCESSING);
+        ReportPostSearchResponse reportPostSearchResponse =
+                createReportPostSearchResponse(1L, "first member",
+                        postSearchResponse, "react note");
+
+        List<ReportPostSearchDocument> reportPostDocumentList =
+                List.of(reportPostSearchDocument);
+        Page<ReportPostSearchDocument> reportPostDocuments =
+                new PageImpl<>(reportPostDocumentList);
+
+        given(reportPostSearchService.search(anyString(), anyInt(), anyInt()))
+                .willReturn(reportPostDocuments);
+        given(reportPostSearchService.entityToDto(any(ReportPostSearchDocument.class)))
+                .willReturn(reportPostSearchResponse);
+
+
+        //when
+        //then
+        mockMvc.perform(get(BASE_URL+"/posts/search?name=member"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].reportPostId").value(1L))
+                .andExpect(jsonPath("$.content[0].memberName").value("first member"))
+                .andExpect(jsonPath("$.content[0].salePost.salePostId").value(10L))
+                .andExpect(jsonPath("$.content[0].reason").value("Inappropriate photo"))
+                .andExpect(jsonPath("$.content[0].status").value("REACTED"));
+
+    }
+
+    @Test
+    @DisplayName("Report Post 검색 성공")
+    void successReportTransaction() throws Exception {
+        //given
+        TransactionSearchResponse transactionSearchResponse =
+                createTransactionSearchResponse(10L, 1L, "seller name",
+                        "buyer name", 10000, TransactionStatus.RECEIVED.getState());
+        ReportTransactionSearchDocument reportTransactionSearchDocument =
+                createReportTransactionSearchDocument(1L, "first member", 10L,
+                        ReportPostType.OTHER_ISSUES.getReportType(), ReportReactStatus.PROCESSING);
+        ReportTransactionSearchResponse reportTransactionSearchResponse =
+                createReportTransactionSearchResponse(1L, "first member",
+                        transactionSearchResponse, "react note");
+
+        List<ReportTransactionSearchDocument> reportTransactionDocumentList =
+                List.of(reportTransactionSearchDocument);
+        Page<ReportTransactionSearchDocument> reportTransactionDocuments =
+                new PageImpl<>(reportTransactionDocumentList);
+
+        given(reportTransactionSearchService.search(anyString(), anyInt(), anyInt()))
+                .willReturn(reportTransactionDocuments);
+        given(reportTransactionSearchService.entityToDto(any(ReportTransactionSearchDocument.class)))
+                .willReturn(reportTransactionSearchResponse);
+
+
+        //when
+        //then
+        mockMvc.perform(get(BASE_URL+"/transactions/search?name=member"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].reportTransactionId").value(1L))
+                .andExpect(jsonPath("$.content[0].memberName").value("first member"))
+                .andExpect(jsonPath("$.content[0].transaction.transactionId").value(10L))
+                .andExpect(jsonPath("$.content[0].reason").value("Economic loss"))
+                .andExpect(jsonPath("$.content[0].status").value("REACTED"));
+
+    }
+}

--- a/src/test/java/com/zerobase/oriticket/report/controller/ReportTransactionControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/report/controller/ReportTransactionControllerTest.java
@@ -1,0 +1,233 @@
+package com.zerobase.oriticket.report.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.entity.*;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.constants.ReportTransactionType;
+import com.zerobase.oriticket.domain.report.controller.ReportTransactionController;
+import com.zerobase.oriticket.domain.report.dto.RegisterReportTransactionRequest;
+import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
+import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
+import com.zerobase.oriticket.domain.report.service.ReportTransactionService;
+import com.zerobase.oriticket.domain.transaction.constants.TransactionStatus;
+import com.zerobase.oriticket.domain.transaction.entity.Transaction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportTransactionController.class)
+public class ReportTransactionControllerTest {
+
+    @MockBean
+    private ReportTransactionService reportTransactionService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final static String BASE_URL = "/transactions";
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 20000;
+    private final static boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "seat info";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Long memberId, Ticket ticket, SaleStatus status){
+        return Post.builder()
+                .salePostId(salePostId)
+                .memberId(memberId)
+                .ticket(ticket)
+                .saleStatus(status)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private Transaction createTransaction(
+            Long transactionId,
+            Post salePost,
+            Long memberId
+    ){
+        return Transaction.builder()
+                .transactionId(transactionId)
+                .salePost(salePost)
+                .memberId(memberId)
+                .startedAt(LocalDateTime.now())
+                .status(TransactionStatus.PENDING)
+                .build();
+    }
+
+    private ReportTransaction createReportTransaction(
+            Long reportTransactionId,
+            Long memberId,
+            Transaction transaction,
+            ReportReactStatus status,
+            LocalDateTime reactedAt,
+            String note
+    ){
+        return ReportTransaction.builder()
+                .reportTransactionId(reportTransactionId)
+                .memberId(memberId)
+                .transaction(transaction)
+                .reason(ReportTransactionType.ECONOMIC_LOSS)
+                .reportedAt(LocalDateTime.now())
+                .status(status)
+                .reactedAt(reactedAt)
+                .note(note)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Report Transaction 등록 성공")
+    void successRegister() throws Exception {
+        //given
+        RegisterReportTransactionRequest registerRequest =
+                RegisterReportTransactionRequest.builder()
+                        .memberId(2L)
+                        .reason("Economic_loss")
+                        .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "두산");
+        Ticket ticket = createTicket(10L, sports, stadium, awayTeam);
+        Post salePost = createPost(14L, 11L, ticket, SaleStatus.FOR_SALE);
+        Transaction transaction = createTransaction(19L, salePost, 2L);
+        ReportTransaction reportTransaction =
+                createReportTransaction(5L, 2L, transaction,
+                        ReportReactStatus.PROCESSING, null, null);
+
+        given(reportTransactionService.register(anyLong(), any(RegisterReportTransactionRequest.class)))
+                .willReturn(reportTransaction);
+
+        //when
+        //then
+        mockMvc.perform(post(BASE_URL+"/19/report")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registerRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reportTransactionId").value(5L))
+                .andExpect(jsonPath("$.memberId").value(2L))
+                .andExpect(jsonPath("$.transaction.transactionId").value(19L))
+                .andExpect(jsonPath("$.transaction.salePostId").value(14L))
+                .andExpect(jsonPath("$.transaction.sellerId").value(11L))
+                .andExpect(jsonPath("$.transaction.buyerId").value(2L))
+                .andExpect(jsonPath("$.transaction.payAmount").doesNotExist())
+                .andExpect(jsonPath("$.transaction.status").value("Pending"))
+                .andExpect(jsonPath("$.transaction.receivedAt").doesNotExist())
+                .andExpect(jsonPath("$.transaction.startedAt").exists())
+                .andExpect(jsonPath("$.transaction.endedAt").doesNotExist())
+                .andExpect(jsonPath("$.reason").value(ReportTransactionType.ECONOMIC_LOSS.getReportType()))
+                .andExpect(jsonPath("$.reportedAt").exists())
+                .andExpect(jsonPath("$.status").value("PROCESSING"))
+                .andExpect(jsonPath("$.reactedAt").doesNotExist())
+                .andExpect(jsonPath("$.note").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("Report Transaction 처리 성공")
+    void successUpdateToReacted() throws Exception {
+        //given
+        UpdateReportRequest updateRequest =
+                UpdateReportRequest.builder()
+                        .note("react note")
+                        .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "두산");
+        Ticket ticket = createTicket(10L, sports, stadium, awayTeam);
+        Post salePost = createPost(14L, 11L, ticket, SaleStatus.FOR_SALE);
+        Transaction transaction = createTransaction(19L, salePost, 2L);
+        ReportTransaction reportTransaction =
+                createReportTransaction(5L, 2L, transaction,
+                        ReportReactStatus.REACTED, LocalDateTime.now(), "react note");
+
+        given(reportTransactionService.updateToReacted(anyLong(), any(UpdateReportRequest.class)))
+                .willReturn(reportTransaction);
+
+        //when
+        //then
+        mockMvc.perform(patch(BASE_URL+"/report/5")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reportTransactionId").value(5L))
+                .andExpect(jsonPath("$.memberId").value(2L))
+                .andExpect(jsonPath("$.transaction.transactionId").value(19L))
+                .andExpect(jsonPath("$.transaction.salePostId").value(14L))
+                .andExpect(jsonPath("$.transaction.sellerId").value(11L))
+                .andExpect(jsonPath("$.transaction.buyerId").value(2L))
+                .andExpect(jsonPath("$.transaction.payAmount").doesNotExist())
+                .andExpect(jsonPath("$.transaction.status").value("Pending"))
+                .andExpect(jsonPath("$.transaction.receivedAt").doesNotExist())
+                .andExpect(jsonPath("$.transaction.startedAt").exists())
+                .andExpect(jsonPath("$.transaction.endedAt").doesNotExist())
+                .andExpect(jsonPath("$.reason").value(ReportTransactionType.ECONOMIC_LOSS.getReportType()))
+                .andExpect(jsonPath("$.reportedAt").exists())
+                .andExpect(jsonPath("$.status").value("REACTED"))
+                .andExpect(jsonPath("$.reactedAt").exists())
+                .andExpect(jsonPath("$.note").value("react note"));
+    }
+}

--- a/src/test/java/com/zerobase/oriticket/report/service/ReportPostServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/report/service/ReportPostServiceTest.java
@@ -1,0 +1,200 @@
+package com.zerobase.oriticket.report.service;
+
+import com.zerobase.oriticket.domain.elasticsearch.report.repository.ReportPostSearchRepository;
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.entity.*;
+import com.zerobase.oriticket.domain.post.repository.PostRepository;
+import com.zerobase.oriticket.domain.report.constants.ReportPostType;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.dto.RegisterReportPostRequest;
+import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
+import com.zerobase.oriticket.domain.report.entity.ReportPost;
+import com.zerobase.oriticket.domain.report.repository.ReportPostRepository;
+import com.zerobase.oriticket.domain.report.service.ReportPostService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class ReportPostServiceTest {
+
+    @Mock
+    private ReportPostRepository reportPostRepository;
+
+    @Mock
+    private ReportPostSearchRepository reportPostSearchRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private ReportPostService reportPostService;
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 20000;
+    private final static boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "seat info";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Long memberId, Ticket ticket, SaleStatus status){
+        return Post.builder()
+                .salePostId(salePostId)
+                .memberId(memberId)
+                .ticket(ticket)
+                .saleStatus(status)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private ReportPost createReportPost(
+            Long reportPostId,
+            Long memberId,
+            Post salePost,
+            ReportReactStatus status,
+            LocalDateTime reactedAt,
+            String note
+    ){
+        return ReportPost.builder()
+                .reportPostId(reportPostId)
+                .memberId(memberId)
+                .salePost(salePost)
+                .reason(ReportPostType.OTHER_ISSUES)
+                .reportedAt(LocalDateTime.now())
+                .status(status)
+                .reactedAt(reactedAt)
+                .note(note)
+                .build();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Report Post 등록 성공")
+    void successRegister(){
+        //given
+        RegisterReportPostRequest registerRequest =
+                RegisterReportPostRequest.builder()
+                        .memberId(2L)
+                        .reason("Other_issues")
+                        .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "두산");
+        Ticket ticket = createTicket(10L, sports, stadium, awayTeam);
+        Post salePost = createPost(14L, 11L, ticket, SaleStatus.FOR_SALE);
+        ReportPost reportPost = createReportPost(5L, 2L, salePost,
+                ReportReactStatus.PROCESSING, null, null);
+
+        given(postRepository.findById(anyLong()))
+                .willReturn(Optional.of(salePost));
+        given(reportPostRepository.save(any(ReportPost.class)))
+                .willReturn(reportPost);
+
+        //when
+        ReportPost fetchedReportPost = reportPostService.register(14L, registerRequest);
+
+        //then
+        assertThat(fetchedReportPost.getReportPostId()).isEqualTo(5L);
+        assertThat(fetchedReportPost.getMemberId()).isEqualTo(2L);
+        assertThat(fetchedReportPost.getSalePost()).isEqualTo(salePost);
+        assertThat(fetchedReportPost.getReason()).isEqualTo(ReportPostType.OTHER_ISSUES);
+        assertNotNull(fetchedReportPost.getReportedAt());
+        assertThat(fetchedReportPost.getStatus()).isEqualTo(ReportReactStatus.PROCESSING);
+        assertNull(fetchedReportPost.getReactedAt());
+        assertNull(fetchedReportPost.getNote());
+
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Report Post 처리 성공")
+    void successUpdateToReacted(){
+        //given
+        UpdateReportRequest updateRequest =
+                UpdateReportRequest.builder()
+                        .note("react note")
+                        .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "두산");
+        Ticket ticket = createTicket(10L, sports, stadium, awayTeam);
+        Post salePost = createPost(14L, 11L, ticket, SaleStatus.FOR_SALE);
+        ReportPost reportPost = createReportPost(5L, 2L, salePost,
+                ReportReactStatus.PROCESSING, LocalDateTime.now(), "react note");
+
+        given(reportPostRepository.findById(anyLong()))
+                .willReturn(Optional.of(reportPost));
+        given(reportPostRepository.save(any(ReportPost.class)))
+                .willReturn(reportPost);
+
+        //when
+        ReportPost fetchedReportPost = reportPostService.updateToReacted(14L, updateRequest);
+
+        //then
+        assertThat(fetchedReportPost.getReportPostId()).isEqualTo(5L);
+        assertThat(fetchedReportPost.getMemberId()).isEqualTo(2L);
+        assertThat(fetchedReportPost.getSalePost()).isEqualTo(salePost);
+        assertThat(fetchedReportPost.getReason()).isEqualTo(ReportPostType.OTHER_ISSUES);
+        assertNotNull(fetchedReportPost.getReportedAt());
+        assertThat(fetchedReportPost.getStatus()).isEqualTo(ReportReactStatus.REACTED);
+        assertNotNull(fetchedReportPost.getReactedAt());
+        assertThat(fetchedReportPost.getNote()).isEqualTo("react note");
+
+    }
+}

--- a/src/test/java/com/zerobase/oriticket/report/service/ReportTransactionServiceTest.java
+++ b/src/test/java/com/zerobase/oriticket/report/service/ReportTransactionServiceTest.java
@@ -1,0 +1,219 @@
+package com.zerobase.oriticket.report.service;
+
+import com.zerobase.oriticket.domain.elasticsearch.report.repository.ReportTransactionSearchRepository;
+import com.zerobase.oriticket.domain.post.constants.SaleStatus;
+import com.zerobase.oriticket.domain.post.entity.*;
+import com.zerobase.oriticket.domain.report.constants.ReportReactStatus;
+import com.zerobase.oriticket.domain.report.constants.ReportTransactionType;
+import com.zerobase.oriticket.domain.report.dto.RegisterReportTransactionRequest;
+import com.zerobase.oriticket.domain.report.dto.UpdateReportRequest;
+import com.zerobase.oriticket.domain.report.entity.ReportTransaction;
+import com.zerobase.oriticket.domain.report.repository.ReportTransactionRepository;
+import com.zerobase.oriticket.domain.report.service.ReportTransactionService;
+import com.zerobase.oriticket.domain.transaction.constants.TransactionStatus;
+import com.zerobase.oriticket.domain.transaction.entity.Transaction;
+import com.zerobase.oriticket.domain.transaction.repository.TransactionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class ReportTransactionServiceTest {
+
+    @Mock
+    private ReportTransactionRepository reportTransactionRepository;
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @Mock
+    private ReportTransactionSearchRepository reportTransactionSearchRepository;
+
+    @InjectMocks
+    private ReportTransactionService reportTransactionService;
+
+    private final static Integer QUANTITY = 1;
+    private final static Integer SALE_PRICE = 10000;
+    private final static Integer ORIGINAL_PRICE = 20000;
+    private final static boolean IS_SUCCESSIVE = false;
+    private final static String SEAT_INFO = "seat info";
+    private final static String IMG_URL = "image url";
+    private final static String NOTE = "note";
+
+    private Sports createSports(Long sportsId, String sportsName){
+        return Sports.builder()
+                .sportsId(sportsId)
+                .sportsName(sportsName)
+                .build();
+    }
+
+    private Stadium createStadium(Long stadiumId, Sports sports, String stadiumName, String homeTeamName){
+        return Stadium.builder()
+                .stadiumId(stadiumId)
+                .sports(sports)
+                .stadiumName(stadiumName)
+                .homeTeamName(homeTeamName)
+                .build();
+    }
+
+    private AwayTeam createAwayTeam(Long awayTeamId, Sports sports, String awayTeamName){
+        return AwayTeam.builder()
+                .awayTeamId(awayTeamId)
+                .sports(sports)
+                .awayTeamName(awayTeamName)
+                .build();
+    }
+
+    private Ticket createTicket(Long ticketId, Sports sports, Stadium stadium, AwayTeam awayTeam){
+        return Ticket.builder()
+                .ticketId(ticketId)
+                .sports(sports)
+                .stadium(stadium)
+                .awayTeam(awayTeam)
+                .quantity(QUANTITY)
+                .salePrice(SALE_PRICE)
+                .originalPrice(ORIGINAL_PRICE)
+                .expirationAt(LocalDateTime.now().plusDays(5))
+                .isSuccessive(IS_SUCCESSIVE)
+                .seatInfo(SEAT_INFO)
+                .imgUrl(IMG_URL)
+                .note(NOTE)
+                .build();
+    }
+
+    private Post createPost(Long salePostId, Long memberId, Ticket ticket, SaleStatus status){
+        return Post.builder()
+                .salePostId(salePostId)
+                .memberId(memberId)
+                .ticket(ticket)
+                .saleStatus(status)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private Transaction createTransaction(
+            Long transactionId,
+            Post salePost,
+            Long memberId
+    ){
+        return Transaction.builder()
+                .transactionId(transactionId)
+                .salePost(salePost)
+                .memberId(memberId)
+                .startedAt(LocalDateTime.now())
+                .status(TransactionStatus.PENDING)
+                .build();
+    }
+
+    private ReportTransaction createReportTransaction(
+            Long reportTransactionId,
+            Long memberId,
+            Transaction transaction,
+            ReportReactStatus status,
+            LocalDateTime reactedAt,
+            String note
+    ){
+        return ReportTransaction.builder()
+                .reportTransactionId(reportTransactionId)
+                .memberId(memberId)
+                .transaction(transaction)
+                .reason(ReportTransactionType.ECONOMIC_LOSS)
+                .reportedAt(LocalDateTime.now())
+                .status(status)
+                .reactedAt(reactedAt)
+                .note(note)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Report Transaction 등록 성공")
+    void successRegister() {
+        //given
+        RegisterReportTransactionRequest registerRequest =
+                RegisterReportTransactionRequest.builder()
+                        .memberId(2L)
+                        .reason("Economic_loss")
+                        .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "두산");
+        Ticket ticket = createTicket(10L, sports, stadium, awayTeam);
+        Post salePost = createPost(14L, 11L, ticket, SaleStatus.FOR_SALE);
+        Transaction transaction = createTransaction(19L, salePost, 2L);
+        ReportTransaction reportTransaction =
+                createReportTransaction(5L, 2L, transaction,
+                        ReportReactStatus.PROCESSING, null, null);
+
+        given(transactionRepository.findById(anyLong()))
+                .willReturn(Optional.of(transaction));
+        given(reportTransactionRepository.save(any(ReportTransaction.class)))
+                .willReturn(reportTransaction);
+
+        //when
+        ReportTransaction fetchedReportTransaction = reportTransactionService.register(19L, registerRequest);
+
+        //then
+        assertThat(fetchedReportTransaction.getReportTransactionId()).isEqualTo(5L);
+        assertThat(fetchedReportTransaction.getMemberId()).isEqualTo(2L);
+        assertThat(fetchedReportTransaction.getTransaction()).isEqualTo(transaction);
+        assertThat(fetchedReportTransaction.getReason()).isEqualTo(ReportTransactionType.ECONOMIC_LOSS);
+        assertNotNull(fetchedReportTransaction.getReportedAt());
+        assertThat(fetchedReportTransaction.getStatus()).isEqualTo(ReportReactStatus.PROCESSING);
+        assertNull(fetchedReportTransaction.getReactedAt());
+        assertNull(fetchedReportTransaction.getNote());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Report Transaction 처리 성공")
+    void successUpdateToReacted() {
+        //given
+        UpdateReportRequest updateRequest =
+                UpdateReportRequest.builder()
+                        .note("react note")
+                        .build();
+        Sports sports = createSports(1L, "야구");
+        Stadium stadium = createStadium(1L, sports, "고척돔", "키움");
+        AwayTeam awayTeam = createAwayTeam(1L, sports, "두산");
+        Ticket ticket = createTicket(10L, sports, stadium, awayTeam);
+        Post salePost = createPost(14L, 11L, ticket, SaleStatus.FOR_SALE);
+        Transaction transaction = createTransaction(19L, salePost, 2L);
+        ReportTransaction reportTransaction =
+                createReportTransaction(5L, 2L, transaction,
+                        ReportReactStatus.REACTED, LocalDateTime.now(), "react note");
+
+        given(reportTransactionRepository.findById(anyLong()))
+                .willReturn(Optional.of(reportTransaction));
+        given(reportTransactionRepository.save(any(ReportTransaction.class)))
+                .willReturn(reportTransaction);
+
+        //when
+        ReportTransaction fetchedReportTransaction =
+                reportTransactionService.updateToReacted(5L, updateRequest);
+
+        //then
+        assertThat(fetchedReportTransaction.getReportTransactionId()).isEqualTo(5L);
+        assertThat(fetchedReportTransaction.getMemberId()).isEqualTo(2L);
+        assertThat(fetchedReportTransaction.getTransaction()).isEqualTo(transaction);
+        assertThat(fetchedReportTransaction.getReason()).isEqualTo(ReportTransactionType.ECONOMIC_LOSS);
+        assertNotNull(fetchedReportTransaction.getReportedAt());
+        assertThat(fetchedReportTransaction.getStatus()).isEqualTo(ReportReactStatus.REACTED);
+        assertNotNull(fetchedReportTransaction.getReactedAt());
+        assertThat(fetchedReportTransaction.getNote()).isEqualTo("react note");
+
+    }
+}

--- a/src/test/java/com/zerobase/oriticket/transaction/controller/TransactionFetchControllerTest.java
+++ b/src/test/java/com/zerobase/oriticket/transaction/controller/TransactionFetchControllerTest.java
@@ -78,7 +78,7 @@ public class TransactionFetchControllerTest {
 
         //when
         //then
-        mockMvc.perform(get("/members/1/transaction?status=pending, received"))
+        mockMvc.perform(get("/members/1/transactions?status=pending, received"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.[0].transactionId").value(1L))
@@ -121,7 +121,7 @@ public class TransactionFetchControllerTest {
 
         //when
         //then
-        mockMvc.perform(get("/members/1/transaction?status=completed, canceled"))
+        mockMvc.perform(get("/members/1/transactions?status=completed, canceled"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.[0].transactionId").value(1L))


### PR DESCRIPTION
## 변경사항

### Report
#### ReportPost
- ReportPost 등록 추가
    - 등록 시 salePostId, memberId, reason이 같을경우 중복 신고 방지를 위해 등록이 안되게 구현
- ReportPost 처리 추가
- ReportPost를 신고자 이름으로 검색하는 기능 추가
    - Page로 리턴
    - 리턴 시 신고된 글도 포함해서 보여주도록 구현
    - 리턴 되는 데이터들은 최신순으로 정렬
        - 정렬 기준 : reportedAt, descending()

#### ReportTransaction
- ReportTransaction 등록 추가
    - 등록 시 transactionId, memberId, reason이 같을경우 중복 신고 방지를 위해 등록이 안되게 구현
- ReportTransaction 처리 추가
- ReportTransaction를 신고자 이름으로 검색하는 기능 추가
    - Page로 리턴
    - 리턴 시 신고된 거래도 포함해서 보여주도록 구현
    - 리턴 되는 데이터들은 최신순으로 정렬
        - 정렬 기준 : reportedAt, descending()

### Post
- PostSearchRepository에 쓸데잆이 추가된 findAll 쿼리 메서드 삭제
- Post 검색 시 최신 글이 가장 처음으로 오도록 정렬 기준 추가
    - 정렬 기준 : createdAt, descending()
-

###  Transaction
- 모든 엔드포인트 네이밍을 한가지로 통일
    - "/transaction" -> "/transactions

### 기타
- 테스트 코드들의 중복되는 entity 객체 생성 코드를 create 메서드로 대체

## 변경 예정
- Member 기능 개발 완료시 Post, Transaction에 Member 연동 예정

## 테스트
- [x] 테스트 코드
- [x] API 테스트