### PR TITLE
refactor: post 검색 쿼리 빌더를 이용하도록 수정

### DIFF
--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/post/repository/PostSearchRepository.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/post/repository/PostSearchRepository.java
@@ -6,6 +6,4 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface PostSearchRepository extends ElasticsearchRepository<PostSearchDocument, Long> {
-
-    Page<PostSearchDocument> findAllBySportsNameContainingOrStadiumNameContainingOrHomeTeamNameContainingOrAwayTeamNameContaining(String sportsName, String stadiumName, String homeTeamName, String awayTeamName, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/oriticket/domain/elasticsearch/post/service/PostSearchService.java
+++ b/src/main/java/com/zerobase/oriticket/domain/elasticsearch/post/service/PostSearchService.java
@@ -1,5 +1,8 @@
 package com.zerobase.oriticket.domain.elasticsearch.post.service;
 
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import com.zerobase.oriticket.domain.elasticsearch.post.entity.PostSearchDocument;
 import com.zerobase.oriticket.domain.elasticsearch.post.repository.PostSearchRepository;
 import lombok.RequiredArgsConstructor;
@@ -7,13 +10,22 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchPage;
 import org.springframework.stereotype.Service;
+
+import static co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchPhrase;
 
 @Service
 @RequiredArgsConstructor
 public class PostSearchService {
 
     private final PostSearchRepository postSearchRepository;
+
+    private final ElasticsearchTemplate template;
 
     private final static String CREATED_AT = "createdAt";
     private final Sort sort = Sort.by(CREATED_AT).descending();
@@ -36,10 +48,31 @@ public class PostSearchService {
 
     private Page<PostSearchDocument> searchByCategoryName(String value, int page, int size){
 
-        Pageable pageable = PageRequest.of(page-1, size, sort);
+        Query q = QueryBuilders.bool(builder -> searchPostQuery(builder, value));
 
-        return postSearchRepository.findAllBySportsNameContainingOrStadiumNameContainingOrHomeTeamNameContainingOrAwayTeamNameContaining
-                (value, value, value, value, pageable);
+        SearchHits<PostSearchDocument> searchHit =
+                template.search(NativeQuery.builder()
+                                .withQuery(q)
+                                .build(),
+                        PostSearchDocument.class);
+
+        SearchPage<PostSearchDocument> searchPage =
+                SearchHitSupport.searchPageFor(searchHit, PageRequest.of(page-1, size, sort));
+        return (Page)SearchHitSupport.unwrapSearchHits(searchPage);
+    }
+
+    private BoolQuery.Builder searchPostQuery(BoolQuery.Builder builder, String value){
+        builder.should(
+                matchPhrase(query -> query.field("sportsName").query(value)),
+                matchPhrase(query -> query.field("stadiumName").query(value)),
+                matchPhrase(query -> query.field("homeTeamName").query(value)),
+                matchPhrase(query -> query.field("awayTeamName").query(value))
+        );
+        builder.mustNot(
+                matchPhrase(query -> query.field("saleStatus").query("REPORTED"))
+        );
+
+        return builder;
     }
 
 }


### PR DESCRIPTION
## 변경사항

### Post
- PostSearch의 검색 로직 변경
    - 기존
        - 길고 알아 보기 힘든 Query 메서드로 작성
        - 검색 시 공백(" ")을 포함하면 런타임 에러 발생
    - 변경
        - Query 메서드 대신 Query Builder를 사용
        - 검색 시 공백(" ")을 포함한 검색 가능

### 기타
- FE API 연동 테스트를 위해 main으로 PR

## 변경 예정
- Member 기능 개발 완료시 Post, Transaction에 Member 연동 예정

## 테스트
- [x] 테스트 코드
- [x] API 테스트