### PR TITLE
refactor: CorsFilter 수정

### DIFF
--- a/src/main/java/com/zerobase/oriticket/domain/chat/config/WebSocketBrokerConfig.java
+++ b/src/main/java/com/zerobase/oriticket/domain/chat/config/WebSocketBrokerConfig.java
@@ -19,7 +19,6 @@ public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry){
         registry.addEndpoint("/ws-stomp")
-                .addInterceptors()
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }

--- a/src/main/java/com/zerobase/oriticket/global/config/CorsFilter.java
+++ b/src/main/java/com/zerobase/oriticket/global/config/CorsFilter.java
@@ -3,10 +3,14 @@ package com.zerobase.oriticket.global.config;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
+@Slf4j
 @Component
 public class CorsFilter implements Filter {
 
@@ -15,13 +19,26 @@ public class CorsFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) req;
         HttpServletResponse response = (HttpServletResponse) res;
 
-        response.setHeader("Access-Control-Allow-Origin", "*");
+        List<String> allowUrl = List.of(
+                "https://jxy.me",               // chat debug site url
+                "http://localhost:8080",
+                "http://127.0.0.1:8080",
+                "https://ori-ticket.vercel.app/"
+        );
+        String origin = request.getHeader("origin");
+        log.info("origin url : "+origin);
+
         response.setHeader("Access-Control-Allow-Credentials", "true");
         response.setHeader("Access-Control-Allow-Methods","*");
         response.setHeader("Access-Control-Allow-Headers",
                 "Origin, X-Requested-With, Content-Type, Accept, Authorization");
 
+        if(origin != null && allowUrl.contains(origin)){
+            response.setHeader("Access-Control-Allow-Origin", origin);
+        }
+
         chain.doFilter(req, res);
+
     }
 
     @Override


### PR DESCRIPTION
## 변경사항

### 기타
- Corsfilter에 allowUrl 리스트에 정해둔 유효한 url로 요청이 들어 올 시 Access-Control-Allow-Origin 헤더에 추가 되게 수정
- FE API 연동 테스트를 위해 main으로 PR

## 테스트
- [x] 테스트 코드
- [x] API 테스트